### PR TITLE
feat(core): AsciiDoc - Ability to replace the section title to simple…

### DIFF
--- a/spring-configuration-property-documenter-core/src/main/resources/templates/partials/adoc/content.adoc.hbs
+++ b/spring-configuration-property-documenter-core/src/main/resources/templates/partials/adoc/content.adoc.hbs
@@ -1,7 +1,8 @@
 {{#if moduleName}}== {{moduleName}}{{/if}}
 {{#if moduleDescription}}{{moduleDescription}}{{/if}}
 {{#each propertyGroups}}
-=== {{groupName}}
+ifndef::property-group-simple-title[=== {{groupName}} +]
+ifdef::property-group-simple-title[.*_{{groupName}}_* +]
 *Class:* `{{type}}`
 
 [cols="2,1,3,1,1"]


### PR DESCRIPTION
… title for property groups

- `property-group-simple-title` attribute introduced to have a customization ability on the property group name's appearance

Closes #25 