### PR TITLE
fix(core): Support empty sourceType

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=11.0.10-open
+java=11.0.17-tem

--- a/docs/template-customization.adoc
+++ b/docs/template-customization.adoc
@@ -413,7 +413,7 @@ There are few Java classes to be discovered if you wish:
 |boolean
 |Controls if the properties without any known group should be included or not. It can happen if the input metadata JSON file is missing the group association with its properties.
 |true
-|0.2.5
+|0.3.0
 
 |===
 

--- a/docs/template-customization.adoc
+++ b/docs/template-customization.adoc
@@ -409,6 +409,12 @@ There are few Java classes to be discovered if you wish:
 |true
 |0.2.0
 
+|includeUnknownGroup
+|boolean
+|Controls if the properties without any known group should be included or not. It can happen if the input metadata JSON file is missing the group association with its properties.
+|true
+|0.2.5
+
 |===
 
 .`org.rodnansol.core.generator.template.customization.MarkdownTemplateCustomization`

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
         <javax.servlet-api.version>4.0.0</javax.servlet-api.version>
         <swagger-models.version>2.0.0</swagger-models.version>
         <commons-io.version>2.11.0</commons-io.version>
-        <junit-bom.version>5.9.0</junit-bom.version>
-        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
+        <junit-bom.version>5.9.2</junit-bom.version>
+        <maven-surefire-plugin.version>3.0.0-M9</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M9</maven-failsafe-plugin.version>
         <mockito-core.version>4.6.1</mockito-core.version>
         <mockito-junit-jupiter.version>4.6.1</mockito-junit-jupiter.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
@@ -303,6 +303,24 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <jacoco-agent.destfile>**/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>${maven-failsafe-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <systemPropertyVariables>
                         <jacoco-agent.destfile>**/jacoco.exec</jacoco-agent.destfile>

--- a/samples/single-module/src/main/java/org/rodnansol/MyConfiguration.java
+++ b/samples/single-module/src/main/java/org/rodnansol/MyConfiguration.java
@@ -1,0 +1,16 @@
+package org.rodnansol;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MyConfiguration {
+
+    @Bean
+    @ConfigurationProperties("this.is.a.bean.configuration")
+    public PropertiesForConfiguration propertiesForConfiguration() {
+        return new PropertiesForConfiguration();
+    }
+
+}

--- a/samples/single-module/src/main/java/org/rodnansol/PropertiesForConfiguration.java
+++ b/samples/single-module/src/main/java/org/rodnansol/PropertiesForConfiguration.java
@@ -1,0 +1,17 @@
+package org.rodnansol;
+
+public class PropertiesForConfiguration {
+
+    /**
+     * A field inside a class that is not property by default by within a Configuration class.
+     */
+    private String configurationValue;
+
+    public String getConfigurationValue() {
+        return configurationValue;
+    }
+
+    public void setConfigurationValue(String configurationValue) {
+        this.configurationValue = configurationValue;
+    }
+}

--- a/spring-configuration-property-documenter-core/pom.xml
+++ b/spring-configuration-property-documenter-core/pom.xml
@@ -72,4 +72,43 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>add-integration-test-sources</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/it/java</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-integration-test-resources</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <filtering>true</filtering>
+                                    <directory>src/it/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/spring-configuration-property-documenter-core/src/it/java/org/rodnansol/core/generator/writer/DocumenterIT.java
+++ b/spring-configuration-property-documenter-core/src/it/java/org/rodnansol/core/generator/writer/DocumenterIT.java
@@ -1,0 +1,76 @@
+package org.rodnansol.core.generator.writer;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.rodnansol.core.generator.reader.MetadataReader;
+import org.rodnansol.core.generator.resolver.MetadataInputResolverContext;
+import org.rodnansol.core.generator.template.TemplateCompilerFactory;
+import org.rodnansol.core.generator.template.TemplateType;
+import org.rodnansol.core.generator.template.customization.AsciiDocTemplateCustomization;
+import org.rodnansol.core.project.ProjectFactory;
+import org.rodnansol.core.project.simple.SimpleProject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class DocumenterIT {
+
+    @TempDir
+    Path tempDir;
+
+    Documenter underTest = new Documenter(MetadataReader.INSTANCE, TemplateCompilerFactory.getDefaultProvidedInstance(), MetadataInputResolverContext.INSTANCE);
+
+    public static Stream<TestCase> testCases() {
+        return Stream.of(
+            new TestCase("src/it/resources/it/spring-configuration-metadata-empty-sourceType.json","src/it/resources/it/expected-spring-configuration-metadata-empty-sourceType.adoc")
+        );
+    }
+
+    private void removeLastLines(List<String> lines, int linesToRemove) {
+        for (int i = 0; i < linesToRemove; i++) {
+            lines.remove(lines.size() - 1);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    void readMetadataAndGenerateRenderedFile_shouldReadMetadataFileAndCreateRenderedDocument(TestCase testCase) throws IOException {
+        // Given
+        Path resolve = tempDir.resolve("IT-output.adoc");
+        SimpleProject project = ProjectFactory.ofSimpleProject(new File("."), "IT");
+        CreateDocumentCommand command = new CreateDocumentCommand(project, "IT", new File(testCase.inputFile), TemplateType.ADOC.getSingleTemplate(), resolve.toFile(), new AsciiDocTemplateCustomization());
+
+        // When
+        underTest.readMetadataAndGenerateRenderedFile(command);
+
+        // Then
+        List<String> actualFile = Files.readAllLines(resolve);
+        removeLastLines(actualFile, 3);
+        List<String> expectedFile = Files.readAllLines(Path.of(testCase.expectedFile));
+        removeLastLines(expectedFile, 3);
+        assertThat(actualFile).containsExactlyElementsOf(expectedFile);
+    }
+
+    static class TestCase {
+        final String inputFile;
+        final String expectedFile;
+
+        public TestCase(String inputFile, String expectedFile) {
+            this.inputFile = inputFile;
+            this.expectedFile = expectedFile;
+        }
+    }
+}

--- a/spring-configuration-property-documenter-core/src/it/resources/it/expected-spring-configuration-metadata-empty-sourceType.adoc
+++ b/spring-configuration-property-documenter-core/src/it/resources/it/expected-spring-configuration-metadata-empty-sourceType.adoc
@@ -1,0 +1,52 @@
+
+= IT
+:toc: auto
+:toc-title: Table of Contents
+:toclevels: 4
+
+
+
+
+
+
+
+
+// tag::Without type[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== Without type +]
+ifdef::property-group-simple-title[.*_Without type_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== Without type
+endif::[]
+*Class:* `Unknown`
+
+[cols="2,1,3,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation
+
+|myproduct.features.foobar.enabled
+|java.lang.Boolean
+|Enable the foobar feature
+|true
+|
+
+|myproduct.features.foobar.number
+|java.lang.Number
+|Number value
+|12.99
+|
+
+|myproduct.features.foobar.value
+|java.lang.String
+|String value
+|Hello world
+|
+
+
+|===
+// end::Without type[]
+
+
+
+This is a generated file, generated at: *2023-02-28T20:32:02.384158297*
+

--- a/spring-configuration-property-documenter-core/src/it/resources/it/spring-configuration-metadata-empty-sourceType.json
+++ b/spring-configuration-property-documenter-core/src/it/resources/it/spring-configuration-metadata-empty-sourceType.json
@@ -1,0 +1,24 @@
+{
+  "groups": [],
+  "properties": [
+    {
+      "name": "myproduct.features.foobar.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the foobar feature",
+      "defaultValue": true
+    },
+    {
+      "name": "myproduct.features.foobar.value",
+      "type": "java.lang.String",
+      "description": "String value",
+      "defaultValue": "Hello world"
+    },
+    {
+      "name": "myproduct.features.foobar.number",
+      "type": "java.lang.Number",
+      "description": "Number value",
+      "defaultValue": "12.99"
+    }
+  ],
+  "hints": []
+}

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/MainTemplateData.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/MainTemplateData.java
@@ -4,6 +4,7 @@ import org.rodnansol.core.generator.template.customization.TemplateCustomization
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Class representing the main template data.
@@ -101,5 +102,16 @@ public class MainTemplateData implements TemplateData {
             '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MainTemplateData that = (MainTemplateData) o;
+        return Objects.equals(mainName, that.mainName) && Objects.equals(propertyGroups, that.propertyGroups) && Objects.equals(subTemplateDataList, that.subTemplateDataList) && Objects.equals(mainDescription, that.mainDescription) && Objects.equals(templateCustomization, that.templateCustomization);
+    }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(mainName, propertyGroups, subTemplateDataList, mainDescription, templateCustomization);
+    }
 }

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/PropertyGroup.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/PropertyGroup.java
@@ -12,6 +12,9 @@ import java.util.Objects;
  */
 public class PropertyGroup {
 
+    public static final String WITHOUT_TYPE = "Without type";
+    public static final String UNKNOWN = "Unknown";
+
     private final String groupName;
     private final String type;
     private final String sourceType;
@@ -19,12 +22,32 @@ public class PropertyGroup {
     private PropertyGroup parentGroup;
     private List<PropertyGroup> childrenGroups;
     private boolean nested;
+    private boolean unknownGroup;
 
     public PropertyGroup(String groupName, String type, String sourceType) {
         this.groupName = groupName;
         this.type = type;
         this.sourceType = sourceType;
         this.nested = !type.equals(sourceType);
+    }
+
+    public PropertyGroup(String groupName, String type, String sourceType, List<Property> properties) {
+        this.groupName = groupName;
+        this.type = type;
+        this.sourceType = sourceType;
+        this.nested = !type.equals(sourceType);
+        this.properties = properties;
+    }
+
+    /**
+     * Creates a group that has 'Unknown' type and source type.
+     *
+     * @return unknown group.
+     */
+    public static PropertyGroup createUnknownGroup() {
+        PropertyGroup propertyGroup = new PropertyGroup(WITHOUT_TYPE, UNKNOWN, UNKNOWN);
+        propertyGroup.setUnknownGroup(true);
+        return propertyGroup;
     }
 
     public String getType() {
@@ -67,16 +90,25 @@ public class PropertyGroup {
         return childrenGroups;
     }
 
+    public boolean isUnknownGroup() {
+        return unknownGroup;
+    }
+
+    public void setUnknownGroup(boolean unknownGroup) {
+        this.unknownGroup = unknownGroup;
+    }
+
     /**
      * Add a new child group.
      *
      * @param childGroup group to be added as a new child.
      */
-    public void addChildGroup(PropertyGroup childGroup) {
+    public PropertyGroup addChildGroup(PropertyGroup childGroup) {
         if (childrenGroups == null) {
             childrenGroups = new ArrayList<>();
         }
         childrenGroups.add(childGroup);
+        return this;
     }
 
     /**
@@ -84,11 +116,12 @@ public class PropertyGroup {
      *
      * @param property new property.
      */
-    public void addProperty(Property property) {
+    public PropertyGroup addProperty(Property property) {
         if (properties == null) {
             properties = new ArrayList<>();
         }
         properties.add(property);
+        return this;
     }
 
     @Override
@@ -120,4 +153,5 @@ public class PropertyGroup {
     public int hashCode() {
         return Objects.hash(groupName, type, sourceType, properties, parentGroup, nested);
     }
+
 }

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/AbstractTemplateCustomization.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/AbstractTemplateCustomization.java
@@ -26,7 +26,7 @@ public abstract class AbstractTemplateCustomization implements TemplateCustomiza
     /**
      * If the 'Without type'/Unknown group should be included or not.
      *
-     * @since 0.2.5
+     * @since 0.3.0
      */
     protected boolean includeUnknownGroup = true;
 

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/AbstractTemplateCustomization.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/AbstractTemplateCustomization.java
@@ -1,5 +1,7 @@
 package org.rodnansol.core.generator.template.customization;
 
+import java.util.Objects;
+
 /**
  * Class represents a template customization object.
  *
@@ -12,14 +14,21 @@ public abstract class AbstractTemplateCustomization implements TemplateCustomiza
      * If the header should be enabled or not.
      * @since 0.2.0
      */
-    private boolean headerEnabled = true;
+    protected boolean headerEnabled = true;
 
     /**
      * Should the "Table of Contents" enabled or not.
      *
      * @since 0.2.0
      */
-    private boolean tableOfContentsEnabled = true;
+    protected boolean tableOfContentsEnabled = true;
+
+    /**
+     * If the 'Without type'/Unknown group should be included or not.
+     *
+     * @since 0.2.5
+     */
+    protected boolean includeUnknownGroup = true;
 
     public boolean isHeaderEnabled() {
         return headerEnabled;
@@ -35,5 +44,26 @@ public abstract class AbstractTemplateCustomization implements TemplateCustomiza
 
     public void setTableOfContentsEnabled(boolean tableOfContentsEnabled) {
         this.tableOfContentsEnabled = tableOfContentsEnabled;
+    }
+
+    public boolean isIncludeUnknownGroup() {
+        return includeUnknownGroup;
+    }
+
+    public void setIncludeUnknownGroup(boolean includeUnknownGroup) {
+        this.includeUnknownGroup = includeUnknownGroup;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AbstractTemplateCustomization that = (AbstractTemplateCustomization) o;
+        return headerEnabled == that.headerEnabled && tableOfContentsEnabled == that.tableOfContentsEnabled && includeUnknownGroup == that.includeUnknownGroup;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(headerEnabled, tableOfContentsEnabled, includeUnknownGroup);
     }
 }

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/AsciiDocTemplateCustomization.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/AsciiDocTemplateCustomization.java
@@ -36,8 +36,8 @@ public class AsciiDocTemplateCustomization extends AbstractTemplateCustomization
         this.tocTitle = tocTitle;
     }
 
-    public TocPlacement getTocPlacement() {
-        return tocPlacement;
+    public String getTocPlacement() {
+        return tocPlacement.toLowerCase();
     }
 
     public void setTocPlacement(TocPlacement tocPlacement) {

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/AsciiDocTemplateCustomization.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/AsciiDocTemplateCustomization.java
@@ -1,5 +1,7 @@
 package org.rodnansol.core.generator.template.customization;
 
+import java.util.Objects;
+
 /**
  * Class representing extra customizations for the AsciiDoc template.
  *
@@ -60,4 +62,17 @@ public class AsciiDocTemplateCustomization extends AbstractTemplateCustomization
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        AsciiDocTemplateCustomization that = (AsciiDocTemplateCustomization) o;
+        return tocLevels == that.tocLevels && Objects.equals(tocTitle, that.tocTitle) && tocPlacement == that.tocPlacement;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), tocTitle, tocPlacement, tocLevels);
+    }
 }

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/TemplateCustomization.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/TemplateCustomization.java
@@ -11,7 +11,7 @@ public interface TemplateCustomization {
     /**
      * If the unknown group should be included or not in the final rendered document or not.
      *
-     * @since 0.2.5
+     * @since 0.3.0
      */
     boolean isIncludeUnknownGroup();
 

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/TemplateCustomization.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/customization/TemplateCustomization.java
@@ -8,4 +8,11 @@ package org.rodnansol.core.generator.template.customization;
  */
 public interface TemplateCustomization {
 
+    /**
+     * If the unknown group should be included or not in the final rendered document or not.
+     *
+     * @since 0.2.5
+     */
+    boolean isIncludeUnknownGroup();
+
 }

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/writer/CreateDocumentCommand.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/writer/CreateDocumentCommand.java
@@ -24,7 +24,7 @@ public class CreateDocumentCommand {
 
     public CreateDocumentCommand(Project project, String name, File metadataInput, String template, File output, TemplateCustomization templateCustomization) {
         this.project = Objects.requireNonNull(project, "project is NULL");
-        this.templateCustomization = Objects.requireNonNull(templateCustomization, "templateCustomization is NULL");;
+        this.templateCustomization = Objects.requireNonNull(templateCustomization, "templateCustomization is NULL");
         this.name = Objects.requireNonNull(name, "name is NULL");
         this.metadataInput = Objects.requireNonNull(metadataInput, "metadataStream is NULL");
         this.template = Objects.requireNonNull(template, "template is NULL");

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/writer/Documenter.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/writer/Documenter.java
@@ -5,6 +5,7 @@ import org.rodnansol.core.generator.resolver.MetadataInputResolverContext;
 import org.rodnansol.core.generator.template.MainTemplateData;
 import org.rodnansol.core.generator.template.PropertyGroup;
 import org.rodnansol.core.generator.template.TemplateCompiler;
+import org.rodnansol.core.generator.template.customization.TemplateCustomization;
 import org.rodnansol.core.util.CoreFileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,10 +55,14 @@ public class Documenter {
     private MainTemplateData createTemplateData(CreateDocumentCommand createDocumentCommand) throws IOException {
         try (InputStream inputStream = metadataInputResolverContext.getInputStreamFromFile(createDocumentCommand.getProject(), createDocumentCommand.getMetadataInput())) {
             List<PropertyGroup> propertyGroups = metadataReader.readPropertiesAsPropertyGroupList(inputStream);
+            TemplateCustomization templateCustomization = createDocumentCommand.getTemplateCustomization();
+            if(!templateCustomization.isIncludeUnknownGroup()) {
+                propertyGroups.removeIf(PropertyGroup::isUnknownGroup);
+            }
             MainTemplateData mainTemplateData = MainTemplateData.ofMainSection(createDocumentCommand.getName(), propertyGroups);
             mainTemplateData.setGenerationDate(LocalDateTime.now());
             mainTemplateData.setMainDescription(createDocumentCommand.getDescription());
-            mainTemplateData.setTemplateCustomization(createDocumentCommand.getTemplateCustomization());
+            mainTemplateData.setTemplateCustomization(templateCustomization);
             return mainTemplateData;
         }
     }

--- a/spring-configuration-property-documenter-core/src/main/resources/templates/aggregated/adoc/header.adoc.hbs
+++ b/spring-configuration-property-documenter-core/src/main/resources/templates/aggregated/adoc/header.adoc.hbs
@@ -1,6 +1,6 @@
 {{#templateCustomization}}
 {{#if headerEnabled}}= {{mainName}}{{/if}}
-{{#if tableOfContentsEnabled}}:toc: {{#if tocPlacement}}{{tocPlacement.toLowerCase}}{{/if}}{{/if}}
+{{#if tableOfContentsEnabled}}:toc: {{#if tocPlacement}}{{tocPlacement}}{{/if}}{{/if}}
 {{#if tocTitle}}:toc-title: {{tocTitle}}{{/if}}
 {{#if tocLevels}}:toclevels: {{tocLevels}}{{/if}}
 

--- a/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/reader/MetadataReaderTest.java
+++ b/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/reader/MetadataReaderTest.java
@@ -31,6 +31,12 @@ class MetadataReaderTest {
         return Stream.of(
             arguments(named("Should read file and return empty property groups list when the groups and properties are empty", new ReadPropertiesAsPropertyGroupListTestCase(TEST_RESOURCES_DIRECTORY + "spring-configuration-metadata-empty-groups-and-properties.json",
                 List::of))),
+            arguments(named("Should read file and return non-empty property groups list when the groups are empty but the properties are not and properties are not having associated groups, in this case a new 'Without typ' group should appear", new ReadPropertiesAsPropertyGroupListTestCase(TEST_RESOURCES_DIRECTORY + "spring-configuration-metadata-empty-sourceType.json",
+                () -> {
+                    PropertyGroup expectedMyProperties = new PropertyGroup("Without type", "Unknown", "Unknown");
+                    expectedMyProperties.addProperty(new Property("myproduct.features.foobar.enabled", "java.lang.Boolean", "myproduct.features.foobar.enabled", "Enable the foobar feature", "true", null));
+                    return List.of(expectedMyProperties);
+                }))),
             arguments(named("Should read file and return empty property groups list when the groups and properties are empty", new ReadPropertiesAsPropertyGroupListTestCase(TEST_RESOURCES_DIRECTORY + "spring-configuration-metadata-empty-groups-and-properties.json",
                 List::of))),
             arguments(named("Should read file and return non-empty property groups list when one group is given but no associated properties are present", new ReadPropertiesAsPropertyGroupListTestCase(TEST_RESOURCES_DIRECTORY + "spring-configuration-metadata-one-group-empty-properties.json",

--- a/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/writer/DocumenterTest.java
+++ b/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/writer/DocumenterTest.java
@@ -1,0 +1,122 @@
+package org.rodnansol.core.generator.writer;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.rodnansol.core.generator.reader.MetadataReader;
+import org.rodnansol.core.generator.resolver.MetadataInputResolverContext;
+import org.rodnansol.core.generator.template.MainTemplateData;
+import org.rodnansol.core.generator.template.Property;
+import org.rodnansol.core.generator.template.PropertyGroup;
+import org.rodnansol.core.generator.template.TemplateCompiler;
+import org.rodnansol.core.generator.template.TemplateData;
+import org.rodnansol.core.generator.template.TemplateType;
+import org.rodnansol.core.generator.template.customization.AsciiDocTemplateCustomization;
+import org.rodnansol.core.project.ProjectFactory;
+import org.rodnansol.core.project.simple.SimpleProject;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumenterTest {
+
+    protected static final String TEST_DESCRIPTION = "Test description";
+    protected static final String TEST = "Test";
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    InputStream inputStream;
+
+    @Mock
+    MetadataReader metadataReader;
+
+    @Mock
+    TemplateCompiler templateCompiler;
+
+    @Mock
+    MetadataInputResolverContext metadataInputResolverContext;
+
+    @InjectMocks
+    Documenter underTest;
+
+    @Test
+    void readMetadataAndGenerateRenderedFile_shouldWriteContentToFile() throws IOException {
+        // Given
+        SimpleProject project = ProjectFactory.ofSimpleProject(new File("."), TEST);
+        File inputFile = new File("input-file");
+        File output = tempDir.resolve("output-file").toFile();
+        String singleTemplate = TemplateType.ADOC.getSingleTemplate();
+        CreateDocumentCommand command = new CreateDocumentCommand(project, TEST, inputFile, singleTemplate, output, new AsciiDocTemplateCustomization());
+        command.setDescription(TEST_DESCRIPTION);
+
+        // When
+        when(metadataInputResolverContext.getInputStreamFromFile(project, inputFile)).thenReturn(inputStream);
+        when(metadataReader.readPropertiesAsPropertyGroupList(inputStream)).thenReturn(List.of(
+            PropertyGroup.createUnknownGroup()
+                .addProperty(new Property("org.rodnansol.unknown-type", "java.lang.String")),
+            new PropertyGroup("group1", "type", "sourceType", List.of(new Property("org.rodnansol.value", "java.lang.String"))),
+            new PropertyGroup("group2", "type", "sourceType", List.of(new Property("org.rodnansol.another-value", "java.lang.String")))
+        ));
+        when(templateCompiler.compileTemplate(eq(singleTemplate),any())).thenReturn("Hello World");
+        underTest.readMetadataAndGenerateRenderedFile(command);
+
+        // Then
+        MainTemplateData expectedTemplateData = new MainTemplateData(TEST,List.of(
+            PropertyGroup.createUnknownGroup()
+                .addProperty(new Property("org.rodnansol.unknown-type", "java.lang.String")),
+            new PropertyGroup("group1", "type", "sourceType", List.of(new Property("org.rodnansol.value", "java.lang.String"))),
+            new PropertyGroup("group2", "type", "sourceType", List.of(new Property("org.rodnansol.another-value", "java.lang.String")))
+        ));
+        expectedTemplateData.setTemplateCustomization(new AsciiDocTemplateCustomization());
+        expectedTemplateData.setMainDescription(TEST_DESCRIPTION);
+        verify(templateCompiler).compileTemplate(singleTemplate, expectedTemplateData);
+    }
+
+    @Test
+    void readMetadataAndGenerateRenderedFile_shouldWriteContentToFileButSkipUnknownGroups_whenUnknownGroupIsIgnored() throws IOException {
+        // Given
+        SimpleProject project = ProjectFactory.ofSimpleProject(new File("."), TEST);
+        File inputFile = new File("input-file");
+        File output = tempDir.resolve("output-file").toFile();
+        String singleTemplate = TemplateType.ADOC.getSingleTemplate();
+        AsciiDocTemplateCustomization templateCustomization = new AsciiDocTemplateCustomization();
+        templateCustomization.setIncludeUnknownGroup(false);
+        CreateDocumentCommand command = new CreateDocumentCommand(project, TEST, inputFile, singleTemplate, output, templateCustomization);
+        command.setDescription(TEST_DESCRIPTION);
+
+        // When
+        when(metadataInputResolverContext.getInputStreamFromFile(project, inputFile)).thenReturn(inputStream);
+        when(metadataReader.readPropertiesAsPropertyGroupList(inputStream)).thenReturn(new ArrayList<>(List.of(
+            PropertyGroup.createUnknownGroup()
+                .addProperty(new Property("org.rodnansol.unknown-type", "java.lang.String")),
+            new PropertyGroup("group1", "type", "sourceType", List.of(new Property("org.rodnansol.value", "java.lang.String"))),
+            new PropertyGroup("group2", "type", "sourceType", List.of(new Property("org.rodnansol.another-value", "java.lang.String")))
+        )));
+        when(templateCompiler.compileTemplate(eq(singleTemplate),any())).thenReturn("Hello World");
+        underTest.readMetadataAndGenerateRenderedFile(command);
+
+        // Then
+        MainTemplateData expectedTemplateData = new MainTemplateData(TEST, List.of(
+            new PropertyGroup("group1", "type", "sourceType", List.of(new Property("org.rodnansol.value", "java.lang.String"))),
+            new PropertyGroup("group2", "type", "sourceType", List.of(new Property("org.rodnansol.another-value", "java.lang.String")))
+        ));
+        expectedTemplateData.setTemplateCustomization(templateCustomization);
+        expectedTemplateData.setMainDescription(TEST_DESCRIPTION);
+        verify(templateCompiler).compileTemplate(singleTemplate, expectedTemplateData);
+    }
+}

--- a/spring-configuration-property-documenter-core/src/test/resources/spring-configuration-metadata-empty-sourceType.json
+++ b/spring-configuration-property-documenter-core/src/test/resources/spring-configuration-metadata-empty-sourceType.json
@@ -1,0 +1,12 @@
+{
+  "groups": [],
+  "properties": [
+    {
+      "name": "myproduct.features.foobar.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the foobar feature",
+      "defaultValue": true
+    }
+  ],
+  "hints": []
+}


### PR DESCRIPTION
- If any of the properties are missing the 'sourceType' attribute, they will be put inside an unknown group
- The inclusion of the unknown group properties can be controlled with a new flag for all template types
- IT test introduction

Closes #33