### PR TITLE
feat: add `as_env` Mustache helper that transform properties to ENV_VARIABLE

### DIFF
--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/HandlebarsTemplateCompiler.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/HandlebarsTemplateCompiler.java
@@ -3,6 +3,7 @@ package org.rodnansol.core.generator.template;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.io.ClassPathTemplateLoader;
 import org.rodnansol.core.generator.DocumentGenerationException;
+import org.rodnansol.core.generator.template.handlebars.EnvironmentVariableHelper;
 import org.rodnansol.core.generator.template.handlebars.WorkingDirectoryAwareRecursiveFileTemplateLoader;
 import org.rodnansol.core.generator.template.handlebars.WorkingDirectoryProvider;
 import org.slf4j.Logger;
@@ -19,12 +20,14 @@ import java.io.IOException;
 public class HandlebarsTemplateCompiler implements TemplateCompiler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HandlebarsTemplateCompiler.class);
+    private final Handlebars handlebars = new Handlebars()
+        .registerHelper("as_env", new EnvironmentVariableHelper())
+        .with(new ClassPathTemplateLoader(), new WorkingDirectoryAwareRecursiveFileTemplateLoader(".", WorkingDirectoryProvider.INSTANCE));
 
     public String compileTemplate(String templatePath, TemplateData templateData) throws DocumentGenerationException {
         LOGGER.debug("Compiling template:[{}] with data:[{}]", templatePath, templatePath);
         try {
-            return new Handlebars()
-                .with(new ClassPathTemplateLoader(), new WorkingDirectoryAwareRecursiveFileTemplateLoader(".", WorkingDirectoryProvider.INSTANCE))
+            return handlebars
                 .compile(templatePath)
                 .apply(templateData);
         } catch (IOException e) {

--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/handlebars/EnvironmentVariableHelper.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/template/handlebars/EnvironmentVariableHelper.java
@@ -1,0 +1,19 @@
+package org.rodnansol.core.generator.template.handlebars;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import org.springframework.boot.context.properties.source.SystemEnvironmentPropertyMapperDelegator;
+
+/**
+ * Handlebars helpers transforming property to ENV_VARIABLE
+ *
+ * @author allsimon
+ * @since 0.3.1
+ */
+public class EnvironmentVariableHelper implements Helper<String> {
+
+    @Override
+    public Object apply(String context, Options options) {
+        return SystemEnvironmentPropertyMapperDelegator.convertToEnvVariable(context);
+    }
+}

--- a/spring-configuration-property-documenter-core/src/main/java/org/springframework/boot/context/properties/source/SystemEnvironmentPropertyMapperDelegator.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/springframework/boot/context/properties/source/SystemEnvironmentPropertyMapperDelegator.java
@@ -1,0 +1,19 @@
+package org.springframework.boot.context.properties.source;
+
+/**
+ * Delegate the transformation of a property to the Spring package private {@link SystemEnvironmentPropertyMapper} class.
+ *
+ * @author allsimon
+ * @since 0.3.1
+ */
+public class SystemEnvironmentPropertyMapperDelegator {
+    private SystemEnvironmentPropertyMapperDelegator() {
+    }
+
+    public static String convertToEnvVariable(String property) {
+        var configurationPropertyName = ConfigurationPropertyName.of(property);
+
+        return SystemEnvironmentPropertyMapper.INSTANCE.map(configurationPropertyName)
+            .get(0); //It returns a list and the first element will be the value we are looking forward
+    }
+}

--- a/spring-configuration-property-documenter-core/src/test/java/org/springframework/boot/context/properties/source/SystemEnvironmentPropertyMapperDelegatorTest.java
+++ b/spring-configuration-property-documenter-core/src/test/java/org/springframework/boot/context/properties/source/SystemEnvironmentPropertyMapperDelegatorTest.java
@@ -1,0 +1,20 @@
+package org.springframework.boot.context.properties.source;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SystemEnvironmentPropertyMapperDelegatorTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "server.port,SERVER_PORT", // typical case
+        "host[0].name,HOST_0_NAME", // indexed property
+        "spring.main.banner-mode,SPRING_MAIN_BANNERMODE", // '-' in property name
+    })
+    void convertToEnvVariable(String input, String expected) {
+        assertThat(SystemEnvironmentPropertyMapperDelegator.convertToEnvVariable(input))
+            .isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Linked to #36

This PR adds the `as_env` helper, allowing users to transform properties to their ENV_VARIABLE form: `spring.application.name` to `SPRING_APPLICATION_NAME` .


The expected usage:
```diff
-[cols="2,1,3,1,1"]
+[cols="2,1,3,1,1,3"]
|===
-|Key |Type |Description |Default value |Deprecation
+|Key |Type |Description |Default value |Deprecation |Environment variable
{{#each properties}}
|{{key}}
|{{type}}
|{{description}}
|{{defaultValue}}
|{{propertyDeprecation}}
+|{{as_env fqName}}
{{/each}}
```

If you want I can open another PR that will add this to the default ADOC/MARKDOWN/XML/HTML output (behind a flag ? by default ?)