### PR TITLE
fix(core): When using @ConfigurationProperties without a prefix  (#79)

### DIFF
--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/reader/MetadataReader.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/reader/MetadataReader.java
@@ -83,7 +83,11 @@ public class MetadataReader {
         if (propertyGroup.isUnknownGroup()) {
             property.setKey(property.getFqName());
         } else {
-            property.setKey(property.getFqName().substring(groupName.length() + 1));
+            if(propertyGroup.getGroupName().isBlank()) {
+                property.setKey(property.getFqName());
+            } else {
+                property.setKey(property.getFqName().substring(groupName.length() + 1));
+            }
         }
         return property;
     }

--- a/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/reader/MetadataReaderTest.java
+++ b/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/reader/MetadataReaderTest.java
@@ -1,6 +1,7 @@
 package org.rodnansol.core.generator.reader;
 
 import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -229,6 +230,7 @@ class MetadataReaderTest {
 
         @Test
         @Issue("#71")
+        @DisplayName("Should return the same property only once per property group when input is having the same input type multiple times defined")
         void readPropertiesAsPropertyGroupList_whenSingleTypeIsBeingReusedMultipleTimes() throws FileNotFoundException {
             // Given
             String fileName = TEST_RESOURCES_DIRECTORY + "regression/spring-configuration-metadata-multiple-nested-with-same-type.json";
@@ -263,6 +265,7 @@ class MetadataReaderTest {
 
         @Test
         @Issue("#72")
+        @DisplayName("Should return properties with correct 'key' when type is used multiple times with different prefixes")
         void readPropertiesAsPropertyGroupList() throws FileNotFoundException {
             // Given
             String fileName = TEST_RESOURCES_DIRECTORY + "regression/spring-configuration-metadata-with-variable-field-name.json";
@@ -286,6 +289,26 @@ class MetadataReaderTest {
             List<PropertyGroup> expectedYourProperties1 = List.of(PropertyGroup.createUnknownGroup(), topLevelGroup, nestedFirst, nestedSecond);
             assertThat(propertyGroups)
                     .containsAll(expectedYourProperties1);
+        }
+
+        @Test
+        @Issue("#79")
+        @DisplayName("Should return correct 'key' when property group is having empty name")
+        void readPropertiesAsPropertyGroupList_whenProperyParentIsNotHavingName() throws FileNotFoundException {
+            // Given
+            String fileName = TEST_RESOURCES_DIRECTORY + "regression/spring-configuration-metadata-with-no-prefix-at-parent-level.json";
+
+            // When
+            List<PropertyGroup> propertyGroups = underTest.readPropertiesAsPropertyGroupList(new FileInputStream(fileName));
+
+            // Then
+            PropertyGroup topLevelGroup = new PropertyGroup("", "com.example.springconfigpropertyreproducer.MyConfigurationProperties", "com.example.springconfigpropertyreproducer.MyConfigurationProperties");
+            topLevelGroup.addProperty(new Property("my-property", "java.lang.String", "my-property", "Generic property", "propertyValue", null));
+
+
+            List<PropertyGroup> expectedYourProperties1 = List.of(PropertyGroup.createUnknownGroup(), topLevelGroup);
+            assertThat(propertyGroups)
+                .containsAll(expectedYourProperties1);
         }
     }
 

--- a/spring-configuration-property-documenter-core/src/test/resources/regression/spring-configuration-metadata-with-no-prefix-at-parent-level.json
+++ b/spring-configuration-property-documenter-core/src/test/resources/regression/spring-configuration-metadata-with-no-prefix-at-parent-level.json
@@ -1,0 +1,19 @@
+{
+  "groups": [
+    {
+      "name": "",
+      "type": "com.example.springconfigpropertyreproducer.MyConfigurationProperties",
+      "sourceType": "com.example.springconfigpropertyreproducer.MyConfigurationProperties"
+    }
+  ],
+  "properties": [
+    {
+      "name": "my-property",
+      "type": "java.lang.String",
+      "description": "Generic property",
+      "sourceType": "com.example.springconfigpropertyreproducer.MyConfigurationProperties",
+      "defaultValue": "propertyValue"
+    }
+  ],
+  "hints": []
+}


### PR DESCRIPTION
- Properties with groups without name is now properly rendered

Closes #79 