### PR TITLE
docs(core): Extend README.ADOC with quick usage sections (#85)

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -16,6 +16,7 @@ endif::[]
 :toc:
 :toc-placement!:
 :toclevels: 4
+:latest-version: 0.6.1
 
 [.text-center]
 image:https://img.shields.io/maven-central/v/org.rodnansol/spring-configuration-property-documenter.svg[Maven Central]
@@ -191,6 +192,45 @@ image::{docs-images-prefix}html-result.png[]
 ====
 image::{docs-images-prefix}xml-result.png[]
 ====
+
+=== Try out quickly with Maven
+
+==== Via direct plugin execution
+
+[source,bash,subs=+attributes]
+----
+mvn clean package  \
+  org.rodnansol:spring-configuration-property-documenter-maven-plugin:{latest-version}:generate-property-document \
+  -Dtype=ADOC
+----
+
+An Asciidoc based property documentation should be available in your `target/property-docs` folder.
+
+==== Via minimal pom.xml configuration
+
+.pom.xml
+[source,xml,subs=+attributes]
+----
+<plugin>
+    <groupId>org.rodnansol</groupId>
+    <artifactId>spring-configuration-property-documenter-maven-plugin</artifactId>
+    <version>{latest-version}</version>
+    <executions>
+        <execution>
+            <id>generate-adoc-without-deprecation-and-type</id>
+            <phase>process-classes</phase>
+            <goals>
+                <goal>generate-property-document</goal>
+            </goals>
+            <configuration>
+                <type>ADOC</type>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+----
+
+NOTE: Don't worry, we have a Gradle plugin as well, check it out xref:{docs-url-prefix}gradle-plugin.adoc[here].
 
 == Setup
 === Requirements

--- a/docs/modules/ROOT/pages/maven-plugin.adoc
+++ b/docs/modules/ROOT/pages/maven-plugin.adoc
@@ -39,8 +39,6 @@ The plugin is having multiple <<available-goals-and-config, goals>> at this mome
 Spring's annotation processor will kick in the `compile` phase, and because of that the plugin must be linked after that lifecycle, for example the `process-classes`.
 
 .pom.xml
-[%collapsible]
-====
 [source,xml]
 ----
  <build>
@@ -87,7 +85,6 @@ Spring's annotation processor will kick in the `compile` phase, and because of t
         </plugins>
     </build>
 ----
-====
 
 In this example 3 files are going to be created with different extensions (Markdown, AsciiDoc, HTML).
 


### PR DESCRIPTION
- Readme is extended with a section where the maven plugin usage is presented via a simple terminal call

Closes #85 