### PR TITLE
build(plugin): Activate gradle repos by submodule

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Build & Verify Project
-        run: ./mvnw -Pgradle-build verify
+        run: ./mvnw verify
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3
         if: always() # always run even if the previous step fails

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Stage Files for Release
         run: |
           ./mvnw versions:set -DnewVersion=$RELEASE_VERSION
-          ./mvnw -Prelease,gradle-build deploy -DskipITs -DaltDeploymentRepository=local::file:./target/staging-deploy -pl '!spring-configuration-property-documenter-report'
+          ./mvnw -Prelease deploy -DskipITs -DaltDeploymentRepository=local::file:./target/staging-deploy -pl '!spring-configuration-property-documenter-report'
           ./scripts/jbang-version-release.sh $RELEASE_VERSION
         env:
           RELEASE_VERSION: ${{ inputs.releaseVersion }}

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Stage Files for Snapshot Release
         run: |
           ./mvnw versions:set -DnewVersion=999-SNAPSHOT
-          ./mvnw -Prelease,gradle-build deploy -DaltDeploymentRepository=local::file:./target/staging-deploy -pl '!spring-configuration-property-documenter-report'
+          ./mvnw -Prelease deploy -DaltDeploymentRepository=local::file:./target/staging-deploy -pl '!spring-configuration-property-documenter-report'
           ./scripts/jbang-version-release.sh 999-SNAPSHOT
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v3

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -289,7 +289,7 @@ Please fork the project if you would like to contribute.
 
 The project requires at least Java 11, if sdkman is installed on your machine `sdk e` command could be used in the terminal to set up the required Java version.
 
-- To build the project just run: `mvn verify -Pbuild` - The `build` profile is required to access the Gradle dependencies
+- To build the project just run: `mvn verify`
 - If you want to build the samples run: `mvn install` and then `mvn package -f samples/pom.xml`
 
 === Code formatter

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ MAVEN_HOME := home_dir + "/.sdkman/candidates/maven/3.9.0"
 
 # maven build without tests
 build:
-   mvn -DskipTests clean install -Pbuild
+   mvn -DskipTests clean install
 
 # maven build without tests
 verify:
@@ -33,7 +33,7 @@ debug-multi-module-docs: build
 build-gradle-plugin:
   rm -rf ~/.m2/repository/org/rodnansol/spring-configuration-property-documenter-gradle-plugin
   rm -rf ~/.gradle/caches
-  mvn clean install -Pbuild -pl 'spring-configuration-property-documenter-gradle-plugin'
+  mvn clean install -pl 'spring-configuration-property-documenter-gradle-plugin'
 
 # Dry full-release
 dry-release:
@@ -77,7 +77,7 @@ create-jbang-release version:
 # Snapshot release
 snapshot-release: (create-jbang-release "999-SNAPSHOT")
   mvn versions:set -DnewVersion=999-SNAPSHOT
-  mvn clean -Prelease,gradle-build -DskipTests deploy -DaltDeploymentRepository=local::file:./target/staging-deploy  -pl '!spring-configuration-property-documenter-report'
+  mvn clean -Prelease -DskipTests deploy -DaltDeploymentRepository=local::file:./target/staging-deploy  -pl '!spring-configuration-property-documenter-report'
   mvn jreleaser:release -Prelease -N -Djreleaser-nexus-deploy.active=SNAPSHOT -Djreleaser-github-release.pre-release=true -X
 
 only-snapshot-release:

--- a/spring-configuration-property-documenter-gradle-plugin/pom.xml
+++ b/spring-configuration-property-documenter-gradle-plugin/pom.xml
@@ -106,20 +106,15 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-        <profile>
-            <id>gradle-build</id>
-            <repositories>
-                <repository>
-                    <id>gradle</id>
-                    <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
-                </repository>
-                <repository>
-                    <id>google</id>
-                    <url>https://maven.google.com/</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
+    <repositories>
+        <repository>
+            <id>gradle</id>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
+        </repository>
+        <repository>
+            <id>google</id>
+            <url>https://maven.google.com/</url>
+        </repository>
+    </repositories>
 
 </project>


### PR DESCRIPTION
This removes the "gradle-build" profile used to add repositories for the gradle-plugin submodule, and instead declares the repositories directly. The profile only affects a single independent submodule that will fail to build unless the profile is active, so it seems redundant.

I only noticed this because the build instructions mention a profile `build` that maven complained doesn't exist, so I figured I would submit a doc fix. But, seeing how the actual profile only adds repos to a single module that fails the build without it, I figured this would be more appropriate.