### PR TITLE
feat(core): Sort PropertyGroups by groupName

### DIFF
--- a/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/reader/MetadataReader.java
+++ b/spring-configuration-property-documenter-core/src/main/java/org/rodnansol/core/generator/reader/MetadataReader.java
@@ -14,6 +14,7 @@ import org.springframework.boot.configurationprocessor.metadata.JsonMarshaller;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -99,6 +100,7 @@ public class MetadataReader {
         return propertyGroupsByType.values()
             .stream()
             .flatMap(Collection::stream)
+            .sorted(Comparator.comparing(PropertyGroup::getGroupName))
             .collect(Collectors.toList());
     }
 

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/compact-mode.adoc
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/compact-mode.adoc
@@ -10,24 +10,9 @@
 |Key |Type |Description |Default value |Deprecation
 
 
-|this.is.your.property
-|java.lang.String
-|This is YOUR property.
-|
-|
 |this.is.a.bean.configuration.configuration-value
 |java.lang.String
 |A field inside a class that is not property by default by within a Configuration class.
-|
-|
-|this.is.my.nested.nested-value
-|java.lang.String
-|Nested value.
-|
-|
-|this.is.my.first-level-nested-property.second-level-nested-class.second-level-value
-|java.lang.String
-|Custom nested
 |
 |
 |this.is.my.another-variable
@@ -69,6 +54,21 @@
 |java.lang.String
 |Name of the custom property.
 |ABC
+|
+|this.is.my.first-level-nested-property.second-level-nested-class.second-level-value
+|java.lang.String
+|Custom nested
+|
+|
+|this.is.my.nested.nested-value
+|java.lang.String
+|Nested value.
+|
+|
+|this.is.your.property
+|java.lang.String
+|This is YOUR property.
+|
 |
 
 |===

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/compact-mode.html
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/compact-mode.html
@@ -139,17 +139,17 @@
                 
                     <li><a href="#Unknown group">Unknown group - <code>Unknown</code></a></li>
                 
-                    <li><a href="#this.is.your">this.is.your - <code>org.rodnansol.YourProperties</code></a></li>
-                
                     <li><a href="#this.is.a.bean.configuration">this.is.a.bean.configuration - <code>org.rodnansol.PropertiesForConfiguration</code></a></li>
-                
-                    <li><a href="#this.is.my.nested">this.is.my.nested - <code>org.rodnansol.TopLevelClassNestedProperty</code></a></li>
-                
-                    <li><a href="#this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class - <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code></a></li>
                 
                     <li><a href="#this.is.my">this.is.my - <code>org.rodnansol.MyProperties</code></a></li>
                 
                     <li><a href="#this.is.my.first-level-nested-property">this.is.my.first-level-nested-property - <code>org.rodnansol.FirstLevelNestedProperty</code></a></li>
+                
+                    <li><a href="#this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class - <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code></a></li>
+                
+                    <li><a href="#this.is.my.nested">this.is.my.nested - <code>org.rodnansol.TopLevelClassNestedProperty</code></a></li>
+                
+                    <li><a href="#this.is.your">this.is.your - <code>org.rodnansol.YourProperties</code></a></li>
                 
             </ul>
         
@@ -172,30 +172,9 @@
     </tr>
 </thead>
 <tr>
-        <td>this.is.your.property</td>
-        <td>java.lang.String</td>
-        <td>This is YOUR property.</td>
-        <td></td>
-        <td></td>
-        </tr>
-<tr>
         <td>this.is.a.bean.configuration.configuration-value</td>
         <td>java.lang.String</td>
         <td>A field inside a class that is not property by default by within a Configuration class.</td>
-        <td></td>
-        <td></td>
-        </tr>
-<tr>
-        <td>this.is.my.nested.nested-value</td>
-        <td>java.lang.String</td>
-        <td>Nested value.</td>
-        <td></td>
-        <td></td>
-        </tr>
-<tr>
-        <td>this.is.my.first-level-nested-property.second-level-nested-class.second-level-value</td>
-        <td>java.lang.String</td>
-        <td>Custom nested</td>
         <td></td>
         <td></td>
         </tr>
@@ -253,6 +232,27 @@
         <td>java.lang.String</td>
         <td>Name of the custom property.</td>
         <td>ABC</td>
+        <td></td>
+        </tr>
+<tr>
+        <td>this.is.my.first-level-nested-property.second-level-nested-class.second-level-value</td>
+        <td>java.lang.String</td>
+        <td>Custom nested</td>
+        <td></td>
+        <td></td>
+        </tr>
+<tr>
+        <td>this.is.my.nested.nested-value</td>
+        <td>java.lang.String</td>
+        <td>Nested value.</td>
+        <td></td>
+        <td></td>
+        </tr>
+<tr>
+        <td>this.is.your.property</td>
+        <td>java.lang.String</td>
+        <td>This is YOUR property.</td>
+        <td></td>
         <td></td>
         </tr>
 

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/compact-mode.md
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/compact-mode.md
@@ -1,19 +1,16 @@
 # single-module-example
 ## Table of Contents
 * [**Unknown group** - `Unknown`](#Unknown group)
-* [**this.is.your** - `org.rodnansol.YourProperties`](#this.is.your)
 * [**this.is.a.bean.configuration** - `org.rodnansol.PropertiesForConfiguration`](#this.is.a.bean.configuration)
-* [**this.is.my.nested** - `org.rodnansol.TopLevelClassNestedProperty`](#this.is.my.nested)
-* [**this.is.my.first-level-nested-property.second-level-nested-class** - `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`](#this.is.my.first-level-nested-property.second-level-nested-class)
 * [**this.is.my** - `org.rodnansol.MyProperties`](#this.is.my)
 * [**this.is.my.first-level-nested-property** - `org.rodnansol.FirstLevelNestedProperty`](#this.is.my.first-level-nested-property)
+* [**this.is.my.first-level-nested-property.second-level-nested-class** - `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`](#this.is.my.first-level-nested-property.second-level-nested-class)
+* [**this.is.my.nested** - `org.rodnansol.TopLevelClassNestedProperty`](#this.is.my.nested)
+* [**this.is.your** - `org.rodnansol.YourProperties`](#this.is.your)
 
 |Key|Type|Description|Default value|Deprecation|
 |---|----|-----------|-------------|-----------|
-| this.is.your.property| java.lang.String| This is YOUR property.| | | 
 | this.is.a.bean.configuration.configuration-value| java.lang.String| A field inside a class that is not property by default by within a Configuration class.| | | 
-| this.is.my.nested.nested-value| java.lang.String| Nested value.| | | 
-| this.is.my.first-level-nested-property.second-level-nested-class.second-level-value| java.lang.String| Custom nested| | | 
 | this.is.my.another-variable| java.lang.String| | with default value| Reason: null, use for replacement: null| 
 | this.is.my.date| java.time.LocalDate| | | | 
 | this.is.my.date-time| java.time.LocalDateTime| | | | 
@@ -22,4 +19,7 @@
 | this.is.my.variable| java.lang.String| This is my variable.| | | 
 | this.is.my.first-level-nested-property.desc| java.lang.String| Description of this thing.| 123| | 
 | this.is.my.first-level-nested-property.name| java.lang.String| Name of the custom property.| ABC| | 
+| this.is.my.first-level-nested-property.second-level-nested-class.second-level-value| java.lang.String| Custom nested| | | 
+| this.is.my.nested.nested-value| java.lang.String| Nested value.| | | 
+| this.is.your.property| java.lang.String| This is YOUR property.| | | 
 

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/exclude-group-sample.adoc
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/exclude-group-sample.adoc
@@ -22,30 +22,6 @@ endif::[]
 |===
 // end::Unknown group[]
 
-// tag::this.is.your[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
-ifdef::property-group-simple-title[.*_this.is.your_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.your
-endif::[]
-*Class:* `org.rodnansol.YourProperties`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-|property
-|java.lang.String
-|This is YOUR property.
-|
-|
-|`THIS_IS_YOUR_PROPERTY`
-
-
-|===
-// end::this.is.your[]
-
 // tag::this.is.a.bean.configuration[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.a.bean.configuration +]
 ifdef::property-group-simple-title[.*_this.is.a.bean.configuration_* +]
@@ -69,54 +45,6 @@ endif::[]
 
 |===
 // end::this.is.a.bean.configuration[]
-
-// tag::this.is.my.nested[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
-ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.nested
-endif::[]
-*Class:* `org.rodnansol.TopLevelClassNestedProperty`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-|nested-value
-|java.lang.String
-|Nested value.
-|
-|
-|`THIS_IS_MY_NESTED_NESTEDVALUE`
-
-
-|===
-// end::this.is.my.nested[]
-
-// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
-ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.first-level-nested-property.second-level-nested-class
-endif::[]
-*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-|second-level-value
-|java.lang.String
-|Custom nested
-|
-|
-|`THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE`
-
-
-|===
-// end::this.is.my.first-level-nested-property.second-level-nested-class[]
 
 // tag::this.is.my.first-level-nested-property[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property +]
@@ -148,5 +76,77 @@ endif::[]
 
 |===
 // end::this.is.my.first-level-nested-property[]
+
+// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
+ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.first-level-nested-property.second-level-nested-class
+endif::[]
+*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+|second-level-value
+|java.lang.String
+|Custom nested
+|
+|
+|`THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE`
+
+
+|===
+// end::this.is.my.first-level-nested-property.second-level-nested-class[]
+
+// tag::this.is.my.nested[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
+ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.nested
+endif::[]
+*Class:* `org.rodnansol.TopLevelClassNestedProperty`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+|nested-value
+|java.lang.String
+|Nested value.
+|
+|
+|`THIS_IS_MY_NESTED_NESTEDVALUE`
+
+
+|===
+// end::this.is.my.nested[]
+
+// tag::this.is.your[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
+ifdef::property-group-simple-title[.*_this.is.your_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.your
+endif::[]
+*Class:* `org.rodnansol.YourProperties`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+|property
+|java.lang.String
+|This is YOUR property.
+|
+|
+|`THIS_IS_YOUR_PROPERTY`
+
+
+|===
+// end::this.is.your[]
 
 

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/exclude-property-sample.adoc
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/exclude-property-sample.adoc
@@ -22,30 +22,6 @@ endif::[]
 |===
 // end::Unknown group[]
 
-// tag::this.is.your[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
-ifdef::property-group-simple-title[.*_this.is.your_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.your
-endif::[]
-*Class:* `org.rodnansol.YourProperties`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-|property
-|java.lang.String
-|This is YOUR property.
-|
-|
-|`THIS_IS_YOUR_PROPERTY`
-
-
-|===
-// end::this.is.your[]
-
 // tag::this.is.a.bean.configuration[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.a.bean.configuration +]
 ifdef::property-group-simple-title[.*_this.is.a.bean.configuration_* +]
@@ -62,54 +38,6 @@ endif::[]
 
 |===
 // end::this.is.a.bean.configuration[]
-
-// tag::this.is.my.nested[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
-ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.nested
-endif::[]
-*Class:* `org.rodnansol.TopLevelClassNestedProperty`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-|nested-value
-|java.lang.String
-|Nested value.
-|
-|
-|`THIS_IS_MY_NESTED_NESTEDVALUE`
-
-
-|===
-// end::this.is.my.nested[]
-
-// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
-ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.first-level-nested-property.second-level-nested-class
-endif::[]
-*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-|second-level-value
-|java.lang.String
-|Custom nested
-|
-|
-|`THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE`
-
-
-|===
-// end::this.is.my.first-level-nested-property.second-level-nested-class[]
 
 // tag::this.is.my[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my +]
@@ -200,5 +128,77 @@ endif::[]
 
 |===
 // end::this.is.my.first-level-nested-property[]
+
+// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
+ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.first-level-nested-property.second-level-nested-class
+endif::[]
+*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+|second-level-value
+|java.lang.String
+|Custom nested
+|
+|
+|`THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE`
+
+
+|===
+// end::this.is.my.first-level-nested-property.second-level-nested-class[]
+
+// tag::this.is.my.nested[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
+ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.nested
+endif::[]
+*Class:* `org.rodnansol.TopLevelClassNestedProperty`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+|nested-value
+|java.lang.String
+|Nested value.
+|
+|
+|`THIS_IS_MY_NESTED_NESTEDVALUE`
+
+
+|===
+// end::this.is.my.nested[]
+
+// tag::this.is.your[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
+ifdef::property-group-simple-title[.*_this.is.your_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.your
+endif::[]
+*Class:* `org.rodnansol.YourProperties`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+|property
+|java.lang.String
+|This is YOUR property.
+|
+|
+|`THIS_IS_YOUR_PROPERTY`
+
+
+|===
+// end::this.is.your[]
 
 

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/include-property-sample.adoc
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/include-property-sample.adoc
@@ -22,23 +22,6 @@ endif::[]
 |===
 // end::Unknown group[]
 
-// tag::this.is.your[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
-ifdef::property-group-simple-title[.*_this.is.your_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.your
-endif::[]
-*Class:* `org.rodnansol.YourProperties`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-
-|===
-// end::this.is.your[]
-
 // tag::this.is.a.bean.configuration[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.a.bean.configuration +]
 ifdef::property-group-simple-title[.*_this.is.a.bean.configuration_* +]
@@ -62,40 +45,6 @@ endif::[]
 
 |===
 // end::this.is.a.bean.configuration[]
-
-// tag::this.is.my.nested[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
-ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.nested
-endif::[]
-*Class:* `org.rodnansol.TopLevelClassNestedProperty`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-
-|===
-// end::this.is.my.nested[]
-
-// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
-ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.first-level-nested-property.second-level-nested-class
-endif::[]
-*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-
-|===
-// end::this.is.my.first-level-nested-property.second-level-nested-class[]
 
 // tag::this.is.my[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my +]
@@ -130,5 +79,56 @@ endif::[]
 
 |===
 // end::this.is.my.first-level-nested-property[]
+
+// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
+ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.first-level-nested-property.second-level-nested-class
+endif::[]
+*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+
+|===
+// end::this.is.my.first-level-nested-property.second-level-nested-class[]
+
+// tag::this.is.my.nested[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
+ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.nested
+endif::[]
+*Class:* `org.rodnansol.TopLevelClassNestedProperty`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+
+|===
+// end::this.is.my.nested[]
+
+// tag::this.is.your[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
+ifdef::property-group-simple-title[.*_this.is.your_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.your
+endif::[]
+*Class:* `org.rodnansol.YourProperties`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+
+|===
+// end::this.is.your[]
 
 

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/property-docs/single-module-example-property-docs.adoc
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/property-docs/single-module-example-property-docs.adoc
@@ -22,30 +22,6 @@ endif::[]
 |===
 // end::Random name for the Unknown group[]
 
-// tag::this.is.your[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
-ifdef::property-group-simple-title[.*_this.is.your_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.your
-endif::[]
-*Class:* `org.rodnansol.YourProperties`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-|property
-|java.lang.String
-|This is YOUR property.
-|
-|
-|`THIS_IS_YOUR_PROPERTY`
-
-
-|===
-// end::this.is.your[]
-
 // tag::this.is.a.bean.configuration[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.a.bean.configuration +]
 ifdef::property-group-simple-title[.*_this.is.a.bean.configuration_* +]
@@ -69,54 +45,6 @@ endif::[]
 
 |===
 // end::this.is.a.bean.configuration[]
-
-// tag::this.is.my.nested[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
-ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.nested
-endif::[]
-*Class:* `org.rodnansol.TopLevelClassNestedProperty`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-|nested-value
-|java.lang.String
-|Nested value.
-|
-|
-|`THIS_IS_MY_NESTED_NESTEDVALUE`
-
-
-|===
-// end::this.is.my.nested[]
-
-// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
-ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.first-level-nested-property.second-level-nested-class
-endif::[]
-*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
-[cols="2,1,3,1,1,1"]
-|===
-|Key |Type |Description |Default value |Deprecation|Environment variable 
-
-
-|second-level-value
-|java.lang.String
-|Custom nested
-|
-|
-|`THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE`
-
-
-|===
-// end::this.is.my.first-level-nested-property.second-level-nested-class[]
 
 // tag::this.is.my[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my +]
@@ -207,5 +135,77 @@ endif::[]
 
 |===
 // end::this.is.my.first-level-nested-property[]
+
+// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
+ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.first-level-nested-property.second-level-nested-class
+endif::[]
+*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+|second-level-value
+|java.lang.String
+|Custom nested
+|
+|
+|`THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE`
+
+
+|===
+// end::this.is.my.first-level-nested-property.second-level-nested-class[]
+
+// tag::this.is.my.nested[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
+ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.nested
+endif::[]
+*Class:* `org.rodnansol.TopLevelClassNestedProperty`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+|nested-value
+|java.lang.String
+|Nested value.
+|
+|
+|`THIS_IS_MY_NESTED_NESTEDVALUE`
+
+
+|===
+// end::this.is.my.nested[]
+
+// tag::this.is.your[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
+ifdef::property-group-simple-title[.*_this.is.your_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.your
+endif::[]
+*Class:* `org.rodnansol.YourProperties`
+[cols="2,1,3,1,1,1"]
+|===
+|Key |Type |Description |Default value |Deprecation|Environment variable 
+
+
+|property
+|java.lang.String
+|This is YOUR property.
+|
+|
+|`THIS_IS_YOUR_PROPERTY`
+
+
+|===
+// end::this.is.your[]
 
 

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/property-docs/single-module-example-property-docs.html
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/property-docs/single-module-example-property-docs.html
@@ -139,17 +139,17 @@
                 
                     <li><a href="#Unknown group">Unknown group - <code>Unknown</code></a></li>
                 
-                    <li><a href="#this.is.your">this.is.your - <code>org.rodnansol.YourProperties</code></a></li>
-                
                     <li><a href="#this.is.a.bean.configuration">this.is.a.bean.configuration - <code>org.rodnansol.PropertiesForConfiguration</code></a></li>
-                
-                    <li><a href="#this.is.my.nested">this.is.my.nested - <code>org.rodnansol.TopLevelClassNestedProperty</code></a></li>
-                
-                    <li><a href="#this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class - <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code></a></li>
                 
                     <li><a href="#this.is.my">this.is.my - <code>org.rodnansol.MyProperties</code></a></li>
                 
                     <li><a href="#this.is.my.first-level-nested-property">this.is.my.first-level-nested-property - <code>org.rodnansol.FirstLevelNestedProperty</code></a></li>
+                
+                    <li><a href="#this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class - <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code></a></li>
+                
+                    <li><a href="#this.is.my.nested">this.is.my.nested - <code>org.rodnansol.TopLevelClassNestedProperty</code></a></li>
+                
+                    <li><a href="#this.is.your">this.is.your - <code>org.rodnansol.YourProperties</code></a></li>
                 
             </ul>
         
@@ -177,31 +177,6 @@
         </tbody>
     </table>
     <hr>
-    <h2 id="this.is.your">this.is.your</h2>
-    <b>Class:</b> <code>org.rodnansol.YourProperties</code>
-    <table class="table">
-        <thead>
-    <tr>
-        <th>Key</th>
-        <th>Type</th>
-        <th>Description</th>
-        <th>Default value</th>
-        <th>Deprecation</th>
-        <th>Environment variable</th>
-    </tr>
-</thead>
-        <tbody>
-        <tr>
-                <td>property</td>
-                <td>java.lang.String</td>
-                <td>This is YOUR property.</td>
-                <td></td>
-                <td></td>
-                <td>THIS_IS_YOUR_PROPERTY</td>
-                </tr>
-        </tbody>
-    </table>
-    <hr>
     <h2 id="this.is.a.bean.configuration">this.is.a.bean.configuration</h2>
     <b>Class:</b> <code>org.rodnansol.PropertiesForConfiguration</code>
     <table class="table">
@@ -223,56 +198,6 @@
                 <td></td>
                 <td></td>
                 <td>THIS_IS_A_BEAN_CONFIGURATION_CONFIGURATIONVALUE</td>
-                </tr>
-        </tbody>
-    </table>
-    <hr>
-    <h2 id="this.is.my.nested">this.is.my.nested</h2>
-    <b>Class:</b> <code>org.rodnansol.TopLevelClassNestedProperty</code>
-    <table class="table">
-        <thead>
-    <tr>
-        <th>Key</th>
-        <th>Type</th>
-        <th>Description</th>
-        <th>Default value</th>
-        <th>Deprecation</th>
-        <th>Environment variable</th>
-    </tr>
-</thead>
-        <tbody>
-        <tr>
-                <td>nested-value</td>
-                <td>java.lang.String</td>
-                <td>Nested value.</td>
-                <td></td>
-                <td></td>
-                <td>THIS_IS_MY_NESTED_NESTEDVALUE</td>
-                </tr>
-        </tbody>
-    </table>
-    <hr>
-    <h2 id="this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class</h2>
-    <b>Class:</b> <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code>
-    <table class="table">
-        <thead>
-    <tr>
-        <th>Key</th>
-        <th>Type</th>
-        <th>Description</th>
-        <th>Default value</th>
-        <th>Deprecation</th>
-        <th>Environment variable</th>
-    </tr>
-</thead>
-        <tbody>
-        <tr>
-                <td>second-level-value</td>
-                <td>java.lang.String</td>
-                <td>Custom nested</td>
-                <td></td>
-                <td></td>
-                <td>THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE</td>
                 </tr>
         </tbody>
     </table>
@@ -371,6 +296,81 @@
                 <td>ABC</td>
                 <td></td>
                 <td>THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_NAME</td>
+                </tr>
+        </tbody>
+    </table>
+    <hr>
+    <h2 id="this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class</h2>
+    <b>Class:</b> <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code>
+    <table class="table">
+        <thead>
+    <tr>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Default value</th>
+        <th>Deprecation</th>
+        <th>Environment variable</th>
+    </tr>
+</thead>
+        <tbody>
+        <tr>
+                <td>second-level-value</td>
+                <td>java.lang.String</td>
+                <td>Custom nested</td>
+                <td></td>
+                <td></td>
+                <td>THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE</td>
+                </tr>
+        </tbody>
+    </table>
+    <hr>
+    <h2 id="this.is.my.nested">this.is.my.nested</h2>
+    <b>Class:</b> <code>org.rodnansol.TopLevelClassNestedProperty</code>
+    <table class="table">
+        <thead>
+    <tr>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Default value</th>
+        <th>Deprecation</th>
+        <th>Environment variable</th>
+    </tr>
+</thead>
+        <tbody>
+        <tr>
+                <td>nested-value</td>
+                <td>java.lang.String</td>
+                <td>Nested value.</td>
+                <td></td>
+                <td></td>
+                <td>THIS_IS_MY_NESTED_NESTEDVALUE</td>
+                </tr>
+        </tbody>
+    </table>
+    <hr>
+    <h2 id="this.is.your">this.is.your</h2>
+    <b>Class:</b> <code>org.rodnansol.YourProperties</code>
+    <table class="table">
+        <thead>
+    <tr>
+        <th>Key</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Default value</th>
+        <th>Deprecation</th>
+        <th>Environment variable</th>
+    </tr>
+</thead>
+        <tbody>
+        <tr>
+                <td>property</td>
+                <td>java.lang.String</td>
+                <td>This is YOUR property.</td>
+                <td></td>
+                <td></td>
+                <td>THIS_IS_YOUR_PROPERTY</td>
                 </tr>
         </tbody>
     </table>

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/property-docs/single-module-example-property-docs.md
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/property-docs/single-module-example-property-docs.md
@@ -1,42 +1,24 @@
 # single-module-example
 ## Table of Contents
 * [**Unknown group** - `Unknown`](#Unknown group)
-* [**this.is.your** - `org.rodnansol.YourProperties`](#this.is.your)
 * [**this.is.a.bean.configuration** - `org.rodnansol.PropertiesForConfiguration`](#this.is.a.bean.configuration)
-* [**this.is.my.nested** - `org.rodnansol.TopLevelClassNestedProperty`](#this.is.my.nested)
-* [**this.is.my.first-level-nested-property.second-level-nested-class** - `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`](#this.is.my.first-level-nested-property.second-level-nested-class)
 * [**this.is.my** - `org.rodnansol.MyProperties`](#this.is.my)
 * [**this.is.my.first-level-nested-property** - `org.rodnansol.FirstLevelNestedProperty`](#this.is.my.first-level-nested-property)
+* [**this.is.my.first-level-nested-property.second-level-nested-class** - `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`](#this.is.my.first-level-nested-property.second-level-nested-class)
+* [**this.is.my.nested** - `org.rodnansol.TopLevelClassNestedProperty`](#this.is.my.nested)
+* [**this.is.your** - `org.rodnansol.YourProperties`](#this.is.your)
 
 ### Unknown group
 **Class:** `Unknown`
 
 |Key|Type|Description|Default value|Deprecation|Environment variable |
 |---|----|-----------|-------------|-----------|----------------------|
-### this.is.your
-**Class:** `org.rodnansol.YourProperties`
-
-|Key|Type|Description|Default value|Deprecation|Environment variable |
-|---|----|-----------|-------------|-----------|----------------------|
-| property| java.lang.String| This is YOUR property.| | | `THIS_IS_YOUR_PROPERTY`|
 ### this.is.a.bean.configuration
 **Class:** `org.rodnansol.PropertiesForConfiguration`
 
 |Key|Type|Description|Default value|Deprecation|Environment variable |
 |---|----|-----------|-------------|-----------|----------------------|
 | configuration-value| java.lang.String| A field inside a class that is not property by default by within a Configuration class.| | | `THIS_IS_A_BEAN_CONFIGURATION_CONFIGURATIONVALUE`|
-### this.is.my.nested
-**Class:** `org.rodnansol.TopLevelClassNestedProperty`
-
-|Key|Type|Description|Default value|Deprecation|Environment variable |
-|---|----|-----------|-------------|-----------|----------------------|
-| nested-value| java.lang.String| Nested value.| | | `THIS_IS_MY_NESTED_NESTEDVALUE`|
-### this.is.my.first-level-nested-property.second-level-nested-class
-**Class:** `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
-
-|Key|Type|Description|Default value|Deprecation|Environment variable |
-|---|----|-----------|-------------|-----------|----------------------|
-| second-level-value| java.lang.String| Custom nested| | | `THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE`|
 ### this.is.my
 **Class:** `org.rodnansol.MyProperties`
 
@@ -55,6 +37,24 @@
 |---|----|-----------|-------------|-----------|----------------------|
 | desc| java.lang.String| Description of this thing.| 123| | `THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_DESC`|
 | name| java.lang.String| Name of the custom property.| ABC| | `THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_NAME`|
+### this.is.my.first-level-nested-property.second-level-nested-class
+**Class:** `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
+
+|Key|Type|Description|Default value|Deprecation|Environment variable |
+|---|----|-----------|-------------|-----------|----------------------|
+| second-level-value| java.lang.String| Custom nested| | | `THIS_IS_MY_FIRSTLEVELNESTEDPROPERTY_SECONDLEVELNESTEDCLASS_SECONDLEVELVALUE`|
+### this.is.my.nested
+**Class:** `org.rodnansol.TopLevelClassNestedProperty`
+
+|Key|Type|Description|Default value|Deprecation|Environment variable |
+|---|----|-----------|-------------|-----------|----------------------|
+| nested-value| java.lang.String| Nested value.| | | `THIS_IS_MY_NESTED_NESTEDVALUE`|
+### this.is.your
+**Class:** `org.rodnansol.YourProperties`
+
+|Key|Type|Description|Default value|Deprecation|Environment variable |
+|---|----|-----------|-------------|-----------|----------------------|
+| property| java.lang.String| This is YOUR property.| | | `THIS_IS_YOUR_PROPERTY`|
 
 
 

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/without-type-and-deprecation.adoc
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/without-type-and-deprecation.adoc
@@ -22,27 +22,6 @@ endif::[]
 |===
 // end::Unknown group[]
 
-// tag::this.is.your[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
-ifdef::property-group-simple-title[.*_this.is.your_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.your
-endif::[]
-*Class:* `org.rodnansol.YourProperties`
-[cols="2,3,1"]
-|===
-|Key  |Description |Default value 
-
-
-|property
-|This is YOUR property.
-|
-
-
-|===
-// end::this.is.your[]
-
 // tag::this.is.a.bean.configuration[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.a.bean.configuration +]
 ifdef::property-group-simple-title[.*_this.is.a.bean.configuration_* +]
@@ -63,48 +42,6 @@ endif::[]
 
 |===
 // end::this.is.a.bean.configuration[]
-
-// tag::this.is.my.nested[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
-ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.nested
-endif::[]
-*Class:* `org.rodnansol.TopLevelClassNestedProperty`
-[cols="2,3,1"]
-|===
-|Key  |Description |Default value 
-
-
-|nested-value
-|Nested value.
-|
-
-
-|===
-// end::this.is.my.nested[]
-
-// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
-ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
-ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
-ifdef::property-group-discrete-heading[]
-[discrete]
-=== this.is.my.first-level-nested-property.second-level-nested-class
-endif::[]
-*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
-[cols="2,3,1"]
-|===
-|Key  |Description |Default value 
-
-
-|second-level-value
-|Custom nested
-|
-
-
-|===
-// end::this.is.my.first-level-nested-property.second-level-nested-class[]
 
 // tag::this.is.my[]
 ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my +]
@@ -171,5 +108,68 @@ endif::[]
 
 |===
 // end::this.is.my.first-level-nested-property[]
+
+// tag::this.is.my.first-level-nested-property.second-level-nested-class[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.first-level-nested-property.second-level-nested-class +]
+ifdef::property-group-simple-title[.*_this.is.my.first-level-nested-property.second-level-nested-class_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.first-level-nested-property.second-level-nested-class
+endif::[]
+*Class:* `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
+[cols="2,3,1"]
+|===
+|Key  |Description |Default value 
+
+
+|second-level-value
+|Custom nested
+|
+
+
+|===
+// end::this.is.my.first-level-nested-property.second-level-nested-class[]
+
+// tag::this.is.my.nested[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.my.nested +]
+ifdef::property-group-simple-title[.*_this.is.my.nested_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.my.nested
+endif::[]
+*Class:* `org.rodnansol.TopLevelClassNestedProperty`
+[cols="2,3,1"]
+|===
+|Key  |Description |Default value 
+
+
+|nested-value
+|Nested value.
+|
+
+
+|===
+// end::this.is.my.nested[]
+
+// tag::this.is.your[]
+ifndef::property-group-simple-title,property-group-discrete-heading[=== this.is.your +]
+ifdef::property-group-simple-title[.*_this.is.your_* +]
+ifdef::property-group-discrete-heading[]
+[discrete]
+=== this.is.your
+endif::[]
+*Class:* `org.rodnansol.YourProperties`
+[cols="2,3,1"]
+|===
+|Key  |Description |Default value 
+
+
+|property
+|This is YOUR property.
+|
+
+
+|===
+// end::this.is.your[]
 
 

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/without-type-and-deprecation.html
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/without-type-and-deprecation.html
@@ -139,17 +139,17 @@
                 
                     <li><a href="#Unknown group">Unknown group - <code>Unknown</code></a></li>
                 
-                    <li><a href="#this.is.your">this.is.your - <code>org.rodnansol.YourProperties</code></a></li>
-                
                     <li><a href="#this.is.a.bean.configuration">this.is.a.bean.configuration - <code>org.rodnansol.PropertiesForConfiguration</code></a></li>
-                
-                    <li><a href="#this.is.my.nested">this.is.my.nested - <code>org.rodnansol.TopLevelClassNestedProperty</code></a></li>
-                
-                    <li><a href="#this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class - <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code></a></li>
                 
                     <li><a href="#this.is.my">this.is.my - <code>org.rodnansol.MyProperties</code></a></li>
                 
                     <li><a href="#this.is.my.first-level-nested-property">this.is.my.first-level-nested-property - <code>org.rodnansol.FirstLevelNestedProperty</code></a></li>
+                
+                    <li><a href="#this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class - <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code></a></li>
+                
+                    <li><a href="#this.is.my.nested">this.is.my.nested - <code>org.rodnansol.TopLevelClassNestedProperty</code></a></li>
+                
+                    <li><a href="#this.is.your">this.is.your - <code>org.rodnansol.YourProperties</code></a></li>
                 
             </ul>
         
@@ -177,28 +177,6 @@
         </tbody>
     </table>
     <hr>
-    <h2 id="this.is.your">this.is.your</h2>
-    <b>Class:</b> <code>org.rodnansol.YourProperties</code>
-    <table class="table">
-        <thead>
-    <tr>
-        <th>Key</th>
-        
-        <th>Description</th>
-        <th>Default value</th>
-        
-        
-    </tr>
-</thead>
-        <tbody>
-        <tr>
-                <td>property</td>
-                <td>This is YOUR property.</td>
-                <td></td>
-                </tr>
-        </tbody>
-    </table>
-    <hr>
     <h2 id="this.is.a.bean.configuration">this.is.a.bean.configuration</h2>
     <b>Class:</b> <code>org.rodnansol.PropertiesForConfiguration</code>
     <table class="table">
@@ -216,50 +194,6 @@
         <tr>
                 <td>configuration-value</td>
                 <td>A field inside a class that is not property by default by within a Configuration class.</td>
-                <td></td>
-                </tr>
-        </tbody>
-    </table>
-    <hr>
-    <h2 id="this.is.my.nested">this.is.my.nested</h2>
-    <b>Class:</b> <code>org.rodnansol.TopLevelClassNestedProperty</code>
-    <table class="table">
-        <thead>
-    <tr>
-        <th>Key</th>
-        
-        <th>Description</th>
-        <th>Default value</th>
-        
-        
-    </tr>
-</thead>
-        <tbody>
-        <tr>
-                <td>nested-value</td>
-                <td>Nested value.</td>
-                <td></td>
-                </tr>
-        </tbody>
-    </table>
-    <hr>
-    <h2 id="this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class</h2>
-    <b>Class:</b> <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code>
-    <table class="table">
-        <thead>
-    <tr>
-        <th>Key</th>
-        
-        <th>Description</th>
-        <th>Default value</th>
-        
-        
-    </tr>
-</thead>
-        <tbody>
-        <tr>
-                <td>second-level-value</td>
-                <td>Custom nested</td>
                 <td></td>
                 </tr>
         </tbody>
@@ -335,6 +269,72 @@
                 <td>name</td>
                 <td>Name of the custom property.</td>
                 <td>ABC</td>
+                </tr>
+        </tbody>
+    </table>
+    <hr>
+    <h2 id="this.is.my.first-level-nested-property.second-level-nested-class">this.is.my.first-level-nested-property.second-level-nested-class</h2>
+    <b>Class:</b> <code>org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass</code>
+    <table class="table">
+        <thead>
+    <tr>
+        <th>Key</th>
+        
+        <th>Description</th>
+        <th>Default value</th>
+        
+        
+    </tr>
+</thead>
+        <tbody>
+        <tr>
+                <td>second-level-value</td>
+                <td>Custom nested</td>
+                <td></td>
+                </tr>
+        </tbody>
+    </table>
+    <hr>
+    <h2 id="this.is.my.nested">this.is.my.nested</h2>
+    <b>Class:</b> <code>org.rodnansol.TopLevelClassNestedProperty</code>
+    <table class="table">
+        <thead>
+    <tr>
+        <th>Key</th>
+        
+        <th>Description</th>
+        <th>Default value</th>
+        
+        
+    </tr>
+</thead>
+        <tbody>
+        <tr>
+                <td>nested-value</td>
+                <td>Nested value.</td>
+                <td></td>
+                </tr>
+        </tbody>
+    </table>
+    <hr>
+    <h2 id="this.is.your">this.is.your</h2>
+    <b>Class:</b> <code>org.rodnansol.YourProperties</code>
+    <table class="table">
+        <thead>
+    <tr>
+        <th>Key</th>
+        
+        <th>Description</th>
+        <th>Default value</th>
+        
+        
+    </tr>
+</thead>
+        <tbody>
+        <tr>
+                <td>property</td>
+                <td>This is YOUR property.</td>
+                <td></td>
                 </tr>
         </tbody>
     </table>

--- a/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/without-type-and-deprecation.md
+++ b/spring-configuration-property-documenter-maven-plugin/src/test/resources/single-module-test/without-type-and-deprecation.md
@@ -1,42 +1,24 @@
 # single-module-example
 ## Table of Contents
 * [**Unknown group** - `Unknown`](#Unknown group)
-* [**this.is.your** - `org.rodnansol.YourProperties`](#this.is.your)
 * [**this.is.a.bean.configuration** - `org.rodnansol.PropertiesForConfiguration`](#this.is.a.bean.configuration)
-* [**this.is.my.nested** - `org.rodnansol.TopLevelClassNestedProperty`](#this.is.my.nested)
-* [**this.is.my.first-level-nested-property.second-level-nested-class** - `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`](#this.is.my.first-level-nested-property.second-level-nested-class)
 * [**this.is.my** - `org.rodnansol.MyProperties`](#this.is.my)
 * [**this.is.my.first-level-nested-property** - `org.rodnansol.FirstLevelNestedProperty`](#this.is.my.first-level-nested-property)
+* [**this.is.my.first-level-nested-property.second-level-nested-class** - `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`](#this.is.my.first-level-nested-property.second-level-nested-class)
+* [**this.is.my.nested** - `org.rodnansol.TopLevelClassNestedProperty`](#this.is.my.nested)
+* [**this.is.your** - `org.rodnansol.YourProperties`](#this.is.your)
 
 ### Unknown group
 **Class:** `Unknown`
 
 |Key|Description|Default value|
 |---|-----------|-------------|
-### this.is.your
-**Class:** `org.rodnansol.YourProperties`
-
-|Key|Description|Default value|
-|---|-----------|-------------|
-| property|  This is YOUR property.| |  
 ### this.is.a.bean.configuration
 **Class:** `org.rodnansol.PropertiesForConfiguration`
 
 |Key|Description|Default value|
 |---|-----------|-------------|
 | configuration-value|  A field inside a class that is not property by default by within a Configuration class.| |  
-### this.is.my.nested
-**Class:** `org.rodnansol.TopLevelClassNestedProperty`
-
-|Key|Description|Default value|
-|---|-----------|-------------|
-| nested-value|  Nested value.| |  
-### this.is.my.first-level-nested-property.second-level-nested-class
-**Class:** `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
-
-|Key|Description|Default value|
-|---|-----------|-------------|
-| second-level-value|  Custom nested| |  
 ### this.is.my
 **Class:** `org.rodnansol.MyProperties`
 
@@ -55,6 +37,24 @@
 |---|-----------|-------------|
 | desc|  Description of this thing.| 123|  
 | name|  Name of the custom property.| ABC|  
+### this.is.my.first-level-nested-property.second-level-nested-class
+**Class:** `org.rodnansol.FirstLevelNestedProperty$SecondLevelNestedClass`
+
+|Key|Description|Default value|
+|---|-----------|-------------|
+| second-level-value|  Custom nested| |  
+### this.is.my.nested
+**Class:** `org.rodnansol.TopLevelClassNestedProperty`
+
+|Key|Description|Default value|
+|---|-----------|-------------|
+| nested-value|  Nested value.| |  
+### this.is.your
+**Class:** `org.rodnansol.YourProperties`
+
+|Key|Description|Default value|
+|---|-----------|-------------|
+| property|  This is YOUR property.| |  
 
 
 


### PR DESCRIPTION
Did the quickest thing I could think of. Its a simpler version of what was requested in https://github.com/rodnansol/spring-configuration-property-documenter/issues/88 .

Don't know if you want to add a configuration option or always sorting the read properties is fine, let me know and I can change it if that is the case. 