### PR TITLE
docs: fix service loader file name in template-customization.adoc

### DIFF
--- a/docs/modules/ROOT/pages/template-customization.adoc
+++ b/docs/modules/ROOT/pages/template-customization.adoc
@@ -267,7 +267,7 @@ public interface TemplateCompiler {
 
 === Register custom template compiler
 
-To register your service create a file named `org.rodnansol.core.generator.template.TemplateCompiler` under the `META-INF/services` directory and put your class's fully qualified name into the file.
+To register your service create a file named `org.rodnansol.core.generator.template.compiler.TemplateCompiler` under the `META-INF/services` directory and put your class's fully qualified name into the file.
 
 To make sure you have the necessary classes, at least for now, you have to add the following dependency to your project:
 


### PR DESCRIPTION
Fixed the filename of the service loader file in template-customization.adoc