### PR TITLE
chore(reports): Allure report introduction

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,6 +27,18 @@ jobs:
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/surefire-reports/TEST-*.xml'
+      - name: Allure Report
+        uses: allure-actions/allure-report@v2
+        if: always()
+        with:
+          results-dir: '**/target/allure-results'
+          report-dir: 'allure-report'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allure-endpoint: ''
+          allure-project-id: ''
+          allure-results: ''
+        env:
+          ALLURE_RESULTS_DIR: '**/target/allure-results'
 #      - name: Add coverage to PR
 #        id: jacoco
 #        uses: madrapps/jacoco-report@v1.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,4 +67,16 @@ jobs:
       - name: Run JReleaser - Full Release
         run: |
           ./mvnw jreleaser:full-release -Prelease -N
+      - name: Allure Report
+        uses: allure-actions/allure-report@v2
+        if: always()
+        with:
+          results-dir: '**/target/allure-results'
+          report-dir: 'allure-report'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allure-endpoint: ''
+          allure-project-id: ''
+          allure-results: ''
+        env:
+          ALLURE_RESULTS_DIR: '**/target/allure-results'
         

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -46,6 +46,18 @@ jobs:
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/target/surefire-reports/TEST-*.xml'
+      - name: Allure Report
+        uses: allure-actions/allure-report@v2
+        if: always()
+        with:
+          results-dir: '**/target/allure-results'
+          report-dir: 'allure-report'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allure-endpoint: ''
+          allure-project-id: ''
+          allure-results: ''
+        env:
+          ALLURE_RESULTS_DIR: '**/target/allure-results'
       - name: Run JReleaser - Snapshot Release
         run: |
           ./mvnw jreleaser:release -Prelease -N -Djreleaser-nexus-deploy.active=SNAPSHOT -Djreleaser-github-release.pre-release=true

--- a/spring-configuration-property-documenter-core/pom.xml
+++ b/spring-configuration-property-documenter-core/pom.xml
@@ -82,6 +82,13 @@
             <artifactId>junit-pioneer</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Allure JUnit5 adapter -->
+        <dependency>
+        <groupId>io.qameta.allure</groupId>
+        <artifactId>allure-junit5</artifactId>
+        <version>2.29.1</version>
+        <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -89,6 +96,23 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <!-- Allure Report Plugin -->
+            <plugin>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>2.11.2</version>
+            </plugin>
+            <!-- Surefire plugin konfiguráció Allure-hoz -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <allure.results.directory>${project.build.directory}/allure-results</allure.results.directory>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/writer/AggregationDocumenterTest.java
+++ b/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/writer/AggregationDocumenterTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.util.List;
 
 import static org.mockito.Mockito.verify;
+import static io.qameta.allure.Allure.step;
 
 @ExtendWith(MockitoExtension.class)
 class AggregationDocumenterTest {
@@ -36,22 +37,23 @@ class AggregationDocumenterTest {
 
     @Test
     void filterGroupsAndProperties_shouldCallPropertyGroupFilterService() {
-        // Given
-        MarkdownTemplateCustomization templateCustomization = new MarkdownTemplateCustomization();
-        CombinedInput combinedInput = new CombinedInput(file, "testSection", "testDescription");
-        combinedInput.setExcludedGroups(List.of("excluded-group"));
-        combinedInput.setExcludedProperties(List.of("excluded-property"));
-        combinedInput.setIncludedGroups(List.of("included-group"));
-        combinedInput.setIncludedProperties(List.of("included-property"));
-        List<PropertyGroup> propertyGroups = List.of();
-
-        // When
-        underTest.filterGroupsAndProperties(templateCustomization, combinedInput, propertyGroups);
-
-        // Then
-        PostProcessPropertyGroupsCommand expectedCommand = new PostProcessPropertyGroupsCommand(templateCustomization, propertyGroups,
-            List.of("excluded-group"), List.of("included-group"),
-            List.of("excluded-property"), List.of("included-property"));
-        verify(propertyGroupFilterService).postProcessPropertyGroups(expectedCommand);
+        step("Preparation", () -> {
+            MarkdownTemplateCustomization templateCustomization = new MarkdownTemplateCustomization();
+            CombinedInput combinedInput = new CombinedInput(file, "testSection", "testDescription");
+            combinedInput.setExcludedGroups(List.of("excluded-group"));
+            combinedInput.setExcludedProperties(List.of("excluded-property"));
+            combinedInput.setIncludedGroups(List.of("included-group"));
+            combinedInput.setIncludedProperties(List.of("included-property"));
+            List<PropertyGroup> propertyGroups = List.of();
+            step("Test logic", () -> {
+                underTest.filterGroupsAndProperties(templateCustomization, combinedInput, propertyGroups);
+                step("Assertions", () -> {
+                    PostProcessPropertyGroupsCommand expectedCommand = new PostProcessPropertyGroupsCommand(templateCustomization, propertyGroups,
+                        List.of("excluded-group"), List.of("included-group"),
+                        List.of("excluded-property"), List.of("included-property"));
+                    verify(propertyGroupFilterService).postProcessPropertyGroups(expectedCommand);
+                });
+            });
+        });
     }
 }

--- a/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/writer/DocumenterTest.java
+++ b/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/writer/DocumenterTest.java
@@ -21,6 +21,7 @@ import org.rodnansol.core.generator.writer.postprocess.PostProcessPropertyGroups
 import org.rodnansol.core.generator.writer.postprocess.PropertyGroupFilterService;
 import org.rodnansol.core.project.ProjectFactory;
 import org.rodnansol.core.project.simple.SimpleProject;
+import static io.qameta.allure.Allure.step;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,38 +64,39 @@ class DocumenterTest {
 
     @Test
     void readMetadataAndGenerateRenderedFile_shouldWriteContentToFile() throws IOException {
-        // Given
-        SimpleProject project = ProjectFactory.ofSimpleProject(new File("."), TEST);
-        File inputFile = new File("input-file");
-        File output = tempDir.resolve("output-file").toFile();
-        String singleTemplate = TemplateType.ADOC.getSingleTemplate(TemplateMode.STANDARD);
-        CreateDocumentCommand command = getCreateDocumentCommand(project, inputFile, output, singleTemplate);
-
-        // When
-        List<PropertyGroup> propertyGroups = List.of(
-            PropertyGroup.createUnknownGroup()
-                .addProperty(new Property("org.rodnansol.unknown-type", "java.lang.String")),
-            new PropertyGroup("group1", "type", "sourceType", List.of(new Property("org.rodnansol.value", "java.lang.String"))),
-            new PropertyGroup("group2", "type", "sourceType", List.of(new Property("org.rodnansol.another-value", "java.lang.String")))
-        );
-        when(metadataInputResolverContext.getInputStreamFromFile(project, inputFile, InputFileResolutionStrategy.RETURN_EMPTY)).thenReturn(inputStream);
-        when(metadataReader.readPropertiesAsPropertyGroupList(inputStream)).thenReturn(propertyGroups);
-        when(templateCompiler.compileTemplate(eq(singleTemplate), any())).thenReturn("Hello World");
-        when(templateCompiler.getMemoryStore()).thenReturn(mock(TemplateCompilerMemoryStore.class));
-        underTest.readMetadataAndGenerateRenderedFile(command);
-
-        // Then
-        MainTemplateData expectedTemplateData = new MainTemplateData(TEST, List.of(
-            PropertyGroup.createUnknownGroup()
-                .addProperty(new Property("org.rodnansol.unknown-type", "java.lang.String")),
-            new PropertyGroup("group1", "type", "sourceType", List.of(new Property("org.rodnansol.value", "java.lang.String"))),
-            new PropertyGroup("group2", "type", "sourceType", List.of(new Property("org.rodnansol.another-value", "java.lang.String")))
-        ));
-        AsciiDocTemplateCustomization expectedTemplateCustomization = new AsciiDocTemplateCustomization();
-        expectedTemplateData.setTemplateCustomization(expectedTemplateCustomization);
-        expectedTemplateData.setMainDescription(TEST_DESCRIPTION);
-        verify(propertyGroupFilterService).postProcessPropertyGroups(new PostProcessPropertyGroupsCommand(expectedTemplateCustomization,propertyGroups, List.of("excluded-group"), List.of("included-group"),List.of("excluded-property"),List.of("included-property")));
-        verify(templateCompiler).compileTemplate(singleTemplate, expectedTemplateData);
+        step("Preparation", () -> {
+            SimpleProject project = ProjectFactory.ofSimpleProject(new File("."), TEST);
+            File inputFile = new File("input-file");
+            File output = tempDir.resolve("output-file").toFile();
+            String singleTemplate = TemplateType.ADOC.getSingleTemplate(TemplateMode.STANDARD);
+            CreateDocumentCommand command = getCreateDocumentCommand(project, inputFile, output, singleTemplate);
+            step("Test logic", () -> {
+                List<PropertyGroup> propertyGroups = List.of(
+                    PropertyGroup.createUnknownGroup()
+                        .addProperty(new Property("org.rodnansol.unknown-type", "java.lang.String")),
+                    new PropertyGroup("group1", "type", "sourceType", List.of(new Property("org.rodnansol.value", "java.lang.String"))),
+                    new PropertyGroup("group2", "type", "sourceType", List.of(new Property("org.rodnansol.another-value", "java.lang.String")))
+                );
+                when(metadataInputResolverContext.getInputStreamFromFile(project, inputFile, InputFileResolutionStrategy.RETURN_EMPTY)).thenReturn(inputStream);
+                when(metadataReader.readPropertiesAsPropertyGroupList(inputStream)).thenReturn(propertyGroups);
+                when(templateCompiler.compileTemplate(eq(singleTemplate), any())).thenReturn("Hello World");
+                when(templateCompiler.getMemoryStore()).thenReturn(mock(TemplateCompilerMemoryStore.class));
+                underTest.readMetadataAndGenerateRenderedFile(command);
+                step("Assertions", () -> {
+                    MainTemplateData expectedTemplateData = new MainTemplateData(TEST, List.of(
+                        PropertyGroup.createUnknownGroup()
+                            .addProperty(new Property("org.rodnansol.unknown-type", "java.lang.String")),
+                        new PropertyGroup("group1", "type", "sourceType", List.of(new Property("org.rodnansol.value", "java.lang.String"))),
+                        new PropertyGroup("group2", "type", "sourceType", List.of(new Property("org.rodnansol.another-value", "java.lang.String")))
+                    ));
+                    AsciiDocTemplateCustomization expectedTemplateCustomization = new AsciiDocTemplateCustomization();
+                    expectedTemplateData.setTemplateCustomization(expectedTemplateCustomization);
+                    expectedTemplateData.setMainDescription(TEST_DESCRIPTION);
+                    verify(propertyGroupFilterService).postProcessPropertyGroups(new PostProcessPropertyGroupsCommand(expectedTemplateCustomization,propertyGroups, List.of("excluded-group"), List.of("included-group"),List.of("excluded-property"),List.of("included-property")));
+                    verify(templateCompiler).compileTemplate(singleTemplate, expectedTemplateData);
+                });
+            });
+        });
     }
 
     private CreateDocumentCommand getCreateDocumentCommand(SimpleProject project, File inputFile, File output, String singleTemplate) {

--- a/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/writer/postprocess/IncludeExcludePropertyPostProcessorTest.java
+++ b/spring-configuration-property-documenter-core/src/test/java/org/rodnansol/core/generator/writer/postprocess/IncludeExcludePropertyPostProcessorTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static io.qameta.allure.Allure.step;
 
 class IncludeExcludePropertyPostProcessorTest {
 
@@ -17,37 +18,39 @@ class IncludeExcludePropertyPostProcessorTest {
 
     @Test
     void filterPropertyGroupProperties_shouldRemoveTheNonIncludedProperties_whenIncludeListIsGiven() {
-        // Given
-        PropertyGroup propertyGroup = new PropertyGroup("this.is.my", "com.example.springpropertysources.MyProperties", "com.example.springpropertysources.MyProperties");
-        propertyGroup.addProperty(new Property("this.is.my.another-variable", "java.lang.String", "another-variable", null, "with default value", new PropertyDeprecation(null, null)));
-        propertyGroup.addProperty(new Property("this.is.my.date", "java.time.LocalDate", "date", null, null, null));
-        propertyGroup.addProperty(new Property("this.is.my.date-time", "java.time.LocalDateTime", "date-time", null, null, null));
-        propertyGroup.addProperty(new Property("this.is.my.duration", "java.time.Duration", "duration", "A duration.", "2d", new PropertyDeprecation("Because it is deprecated", "instant")));
-        propertyGroup.addProperty(new Property("this.is.my.instant", "java.time.Instant", "instant", null, "123", null));
-        propertyGroup.addProperty(new Property("this.is.my.variable", "java.lang.String", "variable", "This is my variable.", null, null));
+        step("Preparation", () -> {
+            PropertyGroup propertyGroup = new PropertyGroup("this.is.my", "com.example.springpropertysources.MyProperties", "com.example.springpropertysources.MyProperties");
+            propertyGroup.addProperty(new Property("this.is.my.another-variable", "java.lang.String", "another-variable", null, "with default value", new PropertyDeprecation(null, null)));
+            propertyGroup.addProperty(new Property("this.is.my.date", "java.time.LocalDate", "date", null, null, null));
+            propertyGroup.addProperty(new Property("this.is.my.date-time", "java.time.LocalDateTime", "date-time", null, null, null));
+            propertyGroup.addProperty(new Property("this.is.my.duration", "java.time.Duration", "duration", "A duration.", "2d", new PropertyDeprecation("Because it is deprecated", "instant")));
+            propertyGroup.addProperty(new Property("this.is.my.instant", "java.time.Instant", "instant", null, "123", null));
+            propertyGroup.addProperty(new Property("this.is.my.variable", "java.lang.String", "variable", "This is my variable.", null, null));
 
-        PropertyGroup nestedPropertyGroup = new PropertyGroup("this.is.my.first-level-nested-property", "com.example.springpropertysources.FirstLevelNestedProperty", "com.example.springpropertysources.MyProperties");
-        nestedPropertyGroup.setNested(true);
-        nestedPropertyGroup.addProperty(new Property("this.is.my.first-level-nested-property.desc", "java.lang.String", "desc", "Description of this thing.", "123", null));
-        nestedPropertyGroup.addProperty(new Property("this.is.my.first-level-nested-property.name", "java.lang.String", "name", "Name of the custom property.", "ABC", null));
-        nestedPropertyGroup.setParentGroup(propertyGroup);
+            PropertyGroup nestedPropertyGroup = new PropertyGroup("this.is.my.first-level-nested-property", "com.example.springpropertysources.FirstLevelNestedProperty", "com.example.springpropertysources.MyProperties");
+            nestedPropertyGroup.setNested(true);
+            nestedPropertyGroup.addProperty(new Property("this.is.my.first-level-nested-property.desc", "java.lang.String", "desc", "Description of this thing.", "123", null));
+            nestedPropertyGroup.addProperty(new Property("this.is.my.first-level-nested-property.name", "java.lang.String", "name", "Name of the custom property.", "ABC", null));
+            nestedPropertyGroup.setParentGroup(propertyGroup);
 
-        List<PropertyGroup> propertyGroups = new ArrayList<>(List.of(propertyGroup, nestedPropertyGroup));
+            List<PropertyGroup> propertyGroups = new ArrayList<>(List.of(propertyGroup, nestedPropertyGroup));
 
-        // When
-        underTest.postProcess(PostProcessPropertyGroupsCommand.ofPropertyFilter(propertyGroups, List.of(), List.of("this.is.my.another-variable", "this.is.my.instant", "this.is.my.first-level-nested-property.name")));
+            step("Test logic", () -> {
+                underTest.postProcess(PostProcessPropertyGroupsCommand.ofPropertyFilter(propertyGroups, List.of(), List.of("this.is.my.another-variable", "this.is.my.instant", "this.is.my.first-level-nested-property.name")));
+                step("Assertions", () -> {
+                    PropertyGroup expectedPropertyGroup = new PropertyGroup("this.is.my", "com.example.springpropertysources.MyProperties", "com.example.springpropertysources.MyProperties");
+                    expectedPropertyGroup.addProperty(new Property("this.is.my.another-variable", "java.lang.String", "another-variable", null, "with default value", new PropertyDeprecation(null, null)));
+                    expectedPropertyGroup.addProperty(new Property("this.is.my.instant", "java.time.Instant", "instant", null, "123", null));
 
-        // Then
-        PropertyGroup expectedPropertyGroup = new PropertyGroup("this.is.my", "com.example.springpropertysources.MyProperties", "com.example.springpropertysources.MyProperties");
-        expectedPropertyGroup.addProperty(new Property("this.is.my.another-variable", "java.lang.String", "another-variable", null, "with default value", new PropertyDeprecation(null, null)));
-        expectedPropertyGroup.addProperty(new Property("this.is.my.instant", "java.time.Instant", "instant", null, "123", null));
+                    PropertyGroup expectedNestedProperyGroup = new PropertyGroup("this.is.my.first-level-nested-property", "com.example.springpropertysources.FirstLevelNestedProperty", "com.example.springpropertysources.MyProperties");
+                    expectedNestedProperyGroup.setNested(true);
+                    expectedNestedProperyGroup.addProperty(new Property("this.is.my.first-level-nested-property.name", "java.lang.String", "name", "Name of the custom property.", "ABC", null));
+                    expectedNestedProperyGroup.setParentGroup(expectedPropertyGroup);
 
-        PropertyGroup expectedNestedProperyGroup = new PropertyGroup("this.is.my.first-level-nested-property", "com.example.springpropertysources.FirstLevelNestedProperty", "com.example.springpropertysources.MyProperties");
-        expectedNestedProperyGroup.setNested(true);
-        expectedNestedProperyGroup.addProperty(new Property("this.is.my.first-level-nested-property.name", "java.lang.String", "name", "Name of the custom property.", "ABC", null));
-        expectedNestedProperyGroup.setParentGroup(expectedPropertyGroup);
-
-        assertThat(propertyGroups).containsExactly(expectedPropertyGroup, expectedNestedProperyGroup);
+                    assertThat(propertyGroups).containsExactly(expectedPropertyGroup, expectedNestedProperyGroup);
+                });
+            });
+        });
     }
 
     @Test


### PR DESCRIPTION
# Allure Reporting Integration for Test Observability

## Overview

This pull request introduces Allure reporting to the project for enhanced test observability and reporting, both locally and in CI.

## What’s Included

- **Allure Dependency:**  
  - Only the `spring-configuration-property-documenter-core` module includes the Allure JUnit 5 adapter (`2.29.1`).
  - Allure dependencies and plugins have been removed from all other modules.

- **Test Improvements:**  
  - All test classes in the core module now use Allure’s imperative mode with `step` calls.
  - Allure steps use static imports and English descriptions for clarity and consistency.

- **CI Integration:**  
  - GitHub Actions workflows (`ci-build.yml`, `release.yml`, `snapshot-release.yml`) have been updated to generate and attach Allure reports to builds using the official Allure GitHub Action.

## Benefits

- Visual, interactive test reports for easier debugging and analysis.
- Consistent, English-language step descriptions in all core tests.
- Automatic Allure report generation and attachment in CI/CD pipelines.

## References

-